### PR TITLE
Determine branch name for downgraded version when updating with "--downgrade" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Short option|Long option|Description
 (Not available)|`--activate-native-d3dcompiler-47`|Activate native 64-bit `d3dcompiler_47.dll` when starting (Needed for D3D11 renderer)
 (Not available)|`--check-windows-steam`|Check for the Windows Steam version on updating when using Proton
 (Not available)|`--disable-proton-overlay`|Disable Steam Overlay when using Proton
-(Not available)|`--downgrade`|Downgrade to latest TruckersMP-compatible version when updating Note: This option implies "--update" option and is ignored if "--beta" ("-b") option is specified
+(Not available)|`--downgrade`|Downgrade to the latest version that is supported by TruckersMP. Note: This option implies "--update" option and is ignored if "--beta" ("-b") option is specified
 (Not available)|`--native-steam-dir`|Choose native Steam installation, useful only if your Steam directory is not detected automatically [Default: `auto`]
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.
@@ -166,7 +166,7 @@ $ truckersmp-cli --ats --start
 
 #### How to downgrade games
 
-When the latest game version is not compatible with TruckersMP yet, if user updates game with `--downgrade` option (that implies `--update`), truckersmp-cli installs the latest TruckersMP-compatible version of game by determining Steam game branch name, using [TruckersMP Web API][truckersmp:webapi].
+When the latest game version is not compatible with TruckersMP yet, the user can downgrade the games with `--downgrade` (that implies `--update`) which installs the latest version that is supported by TruckersMP by determining the Steam game branch name by using [TruckersMP Web API][truckersmp:webapi].
 
 ```
 $ truckersmp-cli --ets2 --downgrade

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Short option|Long option|Description
 (Not available)|`--activate-native-d3dcompiler-47`|Activate native 64-bit `d3dcompiler_47.dll` when starting (Needed for D3D11 renderer)
 (Not available)|`--check-windows-steam`|Check for the Windows Steam version on updating when using Proton
 (Not available)|`--disable-proton-overlay`|Disable Steam Overlay when using Proton
-(Not available)|`--downgrade`|Downgrade to latest TruckersMP-compatible version when updating, ignored if "--beta" ("-b") option is specified
+(Not available)|`--downgrade`|Downgrade to latest TruckersMP-compatible version when updating Note: This option implies "--update" option and is ignored if "--beta" ("-b") option is specified
 (Not available)|`--native-steam-dir`|Choose native Steam installation, useful only if your Steam directory is not detected automatically [Default: `auto`]
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.
@@ -166,10 +166,10 @@ $ truckersmp-cli --ats --start
 
 #### How to downgrade games
 
-When the latest game version is not compatible with TruckersMP yet, if user updates game with `--downgrade` option, truckersmp-cli installs the latest TruckersMP-compatible version of game by determining Steam game branch name, using [TruckersMP Web API][truckersmp:webapi].
+When the latest game version is not compatible with TruckersMP yet, if user updates game with `--downgrade` option (that implies `--update`), truckersmp-cli installs the latest TruckersMP-compatible version of game by determining Steam game branch name, using [TruckersMP Web API][truckersmp:webapi].
 
 ```
-$ truckersmp-cli --ets2 --update --downgrade
+$ truckersmp-cli --ets2 --downgrade
 ```
 
 `--beta` option can be used to specify the branch name directly.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Short option|Long option|Description
 (Not available)|`--activate-native-d3dcompiler-47`|Activate native 64-bit `d3dcompiler_47.dll` when starting (Needed for D3D11 renderer)
 (Not available)|`--check-windows-steam`|Check for the Windows Steam version on updating when using Proton
 (Not available)|`--disable-proton-overlay`|Disable Steam Overlay when using Proton
+(Not available)|`--downgrade`|Downgrade to latest TruckersMP-compatible version when updating, ignored if "--beta" ("-b") option is specified
 (Not available)|`--native-steam-dir`|Choose native Steam installation, useful only if your Steam directory is not detected automatically [Default: `auto`]
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.
@@ -162,6 +163,22 @@ $ truckersmp-cli --ets2 --update
 ```
 $ truckersmp-cli --ats --start
 ```
+
+#### How to downgrade games
+
+When the latest game version is not compatible with TruckersMP yet, if user updates game with `--downgrade` option, truckersmp-cli installs the latest TruckersMP-compatible version of game by determining Steam game branch name, using [TruckersMP Web API][truckersmp:webapi].
+
+```
+$ truckersmp-cli --ets2 --update --downgrade
+```
+
+`--beta` option can be used to specify the branch name directly.
+
+```
+$ truckersmp-cli --ets2 --update --beta temporary_1_39
+```
+
+If both options are given, the branch name from `--beta` option is used.
 
 ### Advanced
 
@@ -286,4 +303,5 @@ and TheUnknownNO's unofficial [TruckersMP-Launcher][github:truckersmp-launcher].
 [steam:windows]: https://steamcdn-a.akamaihd.net/client/installer/SteamSetup.exe
 [truckersmp]: https://truckersmp.com/
 [truckersmp:knowledge-base]: https://truckersmp.com/knowledge-base
+[truckersmp:webapi]: https://stats.truckersmp.com/api
 [wine]: https://www.winehq.org/

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -233,6 +233,11 @@ SteamCMD can use your saved credentials for convenience.
         help="disable Steam Overlay when using Proton",
         action="store_true")
     parser.add_argument(
+        "--downgrade",
+        help="""downgrade to latest TruckersMP-compatible version when updating,
+                ignored if "--beta" ("-b") option is specified""",
+        action="store_true")
+    parser.add_argument(
         "--native-steam-dir", metavar="DIR", type=str,
         default="auto",
         help="""choose native Steam installation,

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -18,6 +18,10 @@ def check_args_errors():
     """Check command-line arguments."""
     # pylint: disable=too-many-branches,too-many-statements
 
+    # "--downgrade" implies "--update"
+    if Args.downgrade:
+        Args.update = True
+
     # checks for updating and/or starting
     if not Args.update and not Args.start:
         logging.info("--update/--start not specified, doing both.")
@@ -234,8 +238,9 @@ SteamCMD can use your saved credentials for convenience.
         action="store_true")
     parser.add_argument(
         "--downgrade",
-        help="""downgrade to latest TruckersMP-compatible version when updating,
-                ignored if "--beta" ("-b") option is specified""",
+        help="""downgrade to latest TruckersMP-compatible version when updating
+                Note: This option implies "--update" option and
+                is ignored if "--beta" ("-b") option is specified""",
         action="store_true")
     parser.add_argument(
         "--native-steam-dir", metavar="DIR", type=str,

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -238,7 +238,7 @@ SteamCMD can use your saved credentials for convenience.
         action="store_true")
     parser.add_argument(
         "--downgrade",
-        help="""downgrade to latest TruckersMP-compatible version when updating
+        help="""downgrade to the latest version supported by TruckersMP
                 Note: This option implies "--update" option and
                 is ignored if "--beta" ("-b") option is specified""",
         action="store_true")

--- a/truckersmp_cli/variables.py
+++ b/truckersmp_cli/variables.py
@@ -71,15 +71,6 @@ class File:
     sdl2_soname = "libSDL2-2.0.so.0"
 
 
-class TMPWebHTML:
-    """Strings in TruckersMP web site."""
-
-    prefix_downgrade = b"<p>TruckersMP does not support the latest game version of "
-    prefix_h2 = b"<h2>"
-    name_ats = b"American Truck Simulator"
-    name_ets2 = b"Euro Truck Simulator 2"
-
-
 class URL:
     """URLs."""
 


### PR DESCRIPTION
This allows users to automatically determine branch name for downgraded version when updating with `--downgrade` option.

Instead, this PR removes automatic branch detection because it has stopped working.

Closes #162.