### PR TITLE
Allow to specify custom ATS/ETS2 launch options

### DIFF
--- a/.github/workflows/build_and_upload_inject_program.yaml
+++ b/.github/workflows/build_and_upload_inject_program.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Build truckersmp-cli.exe
              # we need "make clean" because we already have truckersmp-cli.exe
              # and "make" does nothing even when truckersmp-cli.c is changed
-        run: make clean && make
+        run: make clean && make truckersmp_cli/truckersmp-cli.exe
       - name: Strip truckersmp-cli.exe
         run: x86_64-w64-mingw32-strip truckersmp_cli/truckersmp-cli.exe
       - uses: actions/upload-artifact@v1

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Short option|Long option|Description
 (Not available)|`--check-windows-steam`|Check for the Windows Steam version on updating when using Proton
 (Not available)|`--disable-proton-overlay`|Disable Steam Overlay when using Proton
 (Not available)|`--downgrade`|**DEPRECATED** Downgrade to the latest version that is supported by TruckersMP. Note: This option implies "--update" option and is ignored if "--beta" ("-b") option is specified
-(Not available)|`--game-options OPTIONS`|Specify ATS/ETS2 options [Default: `-nointro -64bit`]
+(Not available)|`--game-options OPTIONS`|Specify ATS/ETS2 options Note: If specifying one option, use `--game-options=-option` format [Default: `-nointro -64bit`]
 (Not available)|`--native-steam-dir`|Choose native Steam installation, useful only if your Steam directory is not detected automatically [Default: `auto`]
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|**DEPRECATED** Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Short option|Long option|Description
 (Not available)|`--check-windows-steam`|Check for the Windows Steam version on updating when using Proton
 (Not available)|`--disable-proton-overlay`|Disable Steam Overlay when using Proton
 (Not available)|`--downgrade`|**DEPRECATED** Downgrade to the latest version that is supported by TruckersMP. Note: This option implies "--update" option and is ignored if "--beta" ("-b") option is specified
+(Not available)|`--game-options OPTIONS`|Specify ATS/ETS2 options [Default: `-nointro -64bit`]
 (Not available)|`--native-steam-dir`|Choose native Steam installation, useful only if your Steam directory is not detected automatically [Default: `auto`]
 (Not available)|`--self-update`|Update files to the latest release and quit
 (Not available)|`--singleplayer`|**DEPRECATED** Start singleplayer game, useful for save editing, using/testing DXVK in singleplayer, etc.

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -280,6 +280,11 @@ SteamCMD can use your saved credentials for convenience.
                 is ignored if "--beta" ("-b") option is specified""",
         action="store_true")
     parser.add_argument(
+        "--game-options", metavar="OPTIONS", type=str,
+        default="-nointro -64bit",
+        help="""specify ATS/ETS2 options
+                [Default: "-nointro -64bit"]""")
+    parser.add_argument(
         "--native-steam-dir", metavar="DIR", type=str,
         default="auto",
         help="""choose native Steam installation,

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -305,13 +305,13 @@ SteamCMD can use your saved credentials for convenience.
         help="""**DEPRECATED** downgrade to the latest version supported by TruckersMP
                 Note: This option implies "--update" option and
                 is ignored if "--beta" ("-b") option is specified""",
-        action="store_true")
+        action="store_true"))
     store_actions.append(parser.add_argument(
         "--game-options", metavar="OPTIONS", type=str,
         default="-nointro -64bit",
         help="""specify ATS/ETS2 options
                 Note: If specifying one option, use "--game-options=-option" format
-                [Default: "-nointro -64bit"]""")
+                [Default: "-nointro -64bit"]""",
         action="store_true"))
     store_actions.append(parser.add_argument(
         "--native-steam-dir", metavar="DIR", type=str,

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -283,6 +283,7 @@ SteamCMD can use your saved credentials for convenience.
         "--game-options", metavar="OPTIONS", type=str,
         default="-nointro -64bit",
         help="""specify ATS/ETS2 options
+                Note: If specifying one option, use "--game-options=-option" format
                 [Default: "-nointro -64bit"]""")
     parser.add_argument(
         "--native-steam-dir", metavar="DIR", type=str,


### PR DESCRIPTION
This PR adds `--game-options=` option. The specified game options are passed to ATS/ETS2.

Closes #163.

Example: `--game-options="-nointro -64bit -sysmouse"`

@Lucki Don't forget to compile `truckersmp-cli.c` and replace original `truckersmp-cli.exe` with compiled executable before testing this.