### PR TITLE
GitHub Actions: Upload to PyPI when repo is "truckersmp-cli/truckersmp-cli"

### DIFF
--- a/.github/workflows/auto_release.yaml
+++ b/.github/workflows/auto_release.yaml
@@ -97,7 +97,7 @@ jobs:
           asset_name: ${{ steps.compress_files.outputs.tarfilename }}.zst
           asset_content_type: application/x-tar
       - name: Upload package to PyPI
-        if: github.repository == 'kakurasan/truckersmp-cli'
+        if: github.repository == 'truckersmp-cli/truckersmp-cli'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
I have added PyPI token for uploading (`secrets.PYPI_TOKEN`) and it should work.

Note: I am still the "sole owner" of truckersmp-cli *on PyPI* and I would like to invite @lhark and @Lucki, but your PyPI usernames are required.