### PR TITLE
start_wine_discord_ipc_bridge(): Don't start executable in this function

### DIFF
--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -17,7 +17,7 @@ from .truckersmp import update_mod
 from .utils import (
     activate_native_d3dcompiler_47, check_libsdl2,
     perform_self_update, set_wine_desktop_registry,
-    start_wine_discord_ipc_bridge, wait_for_steam,
+    setup_wine_discord_ipc_bridge, wait_for_steam,
 )
 from .variables import AppId, Args, Dir, File, URL
 
@@ -230,7 +230,11 @@ def start_with_proton():
     # unless "--without-wine-discord-ipc-bridge" is specified
     ipcbr_proc = None
     if not Args.singleplayer and not Args.without_wine_discord_ipc_bridge:
-        ipcbr_proc = start_wine_discord_ipc_bridge(argv, env)
+        ipcbr_path = setup_wine_discord_ipc_bridge()
+        logging.info("Starting wine-discord-ipc-bridge")
+        ipcbr_proc = subproc.Popen(
+            argv + [ipcbr_path, ],
+            env=env, stdout=subproc.DEVNULL, stderr=subproc.DEVNULL)
 
     # check whether singleplayer or multiplayer
     if Args.singleplayer:
@@ -298,7 +302,11 @@ def start_with_wine():
 
     ipcbr_proc = None
     if not Args.singleplayer and not Args.without_wine_discord_ipc_bridge:
-        ipcbr_proc = start_wine_discord_ipc_bridge(argv, env)
+        ipcbr_path = setup_wine_discord_ipc_bridge()
+        logging.info("Starting wine-discord-ipc-bridge")
+        ipcbr_proc = subproc.Popen(
+            argv + [ipcbr_path, ],
+            env=env, stdout=subproc.DEVNULL, stderr=subproc.DEVNULL)
 
     if "WINEDLLOVERRIDES" not in env:
         env["WINEDLLOVERRIDES"] = ""

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -393,17 +393,13 @@ def perform_self_update():
     logging.info("Self update complete")
 
 
-def start_wine_discord_ipc_bridge(runner, env):
+def setup_wine_discord_ipc_bridge():
     """
-    Check/download/run wine-discord-ipc-bridge.
+    Check and download wine-discord-ipc-bridge.
 
     This checks whether winediscordipcbridge.exe is already downloaded
     and download it only when it is not present.
-    When ready, this starts winediscordipcbridge.exe and
-    returns subprocess.Popen object for its process.
-
-    runner: ["/path/to/proton", "run"] (Proton) or ["/path/to/wine"] (Wine)
-    env: Environment variables
+    When ready, this function returns the path to wine-discord-ipc-bridge.
     """
     # check whether the file is already downloaded
     need_download = True
@@ -423,11 +419,7 @@ def start_wine_discord_ipc_bridge(runner, env):
                 URL.github, [(URL.ipcbrpath, File.ipcbridge, File.ipcbridge_md5), ]):
             sys.exit("Failed to download winediscordipcbridge.exe")
 
-    logging.info("Starting winediscordipcbridge.exe")
-
-    return subproc.Popen(
-        runner + [File.ipcbridge, ],
-        env=env, stdout=subproc.DEVNULL, stderr=subproc.DEVNULL)
+    return File.ipcbridge
 
 
 def set_wine_desktop_registry(prefix, wine, enable):


### PR DESCRIPTION
This PR splits `start_wine_discord_ipc_bridge()` into 2 parts:
* Checking and downloading Discord bridge: No changes
* Starting wine-discord-ipc-bridge: Create `subprocess.Popen` object in `start_with_proton()` (Note: This will be moved to Steam Runtime helper script in #159) / `start_with_wine()`

This PR also changes:
* The name of the function: `setup_wine_discord_ipc_bridge()`
* Return value: The path to `winediscordipcbridge.exe`
    * This value is used when creating `subprocess.Popen` object

See https://github.com/truckersmp-cli/truckersmp-cli/pull/159#issuecomment-824843411