### PR TITLE
Improve printing child process output

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,11 @@
+[MESSAGES CONTROL]
+# In steamruntime_helper.py, we can't call print_child_output()
+# because the helper may be running inside Steam Runtime container
+# and unable to import our modules.
+disable=
+    duplicate-code,
+
+
 [TYPECHECK]
 # Args.* are set dynamically in main.py:
 #

--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -16,8 +16,8 @@ from .steamcmd import update_game
 from .truckersmp import update_mod
 from .utils import (
     activate_native_d3dcompiler_47, check_libsdl2, find_discord_ipc_sockets,
-    get_proton_version, perform_self_update, set_wine_desktop_registry,
-    setup_wine_discord_ipc_bridge, wait_for_steam,
+    get_proton_version, perform_self_update, print_child_output,
+    set_wine_desktop_registry, setup_wine_discord_ipc_bridge, wait_for_steam,
 )
 from .variables import AppId, Args, Dir, File, URL
 
@@ -327,9 +327,8 @@ def start_with_proton():
         with subproc.Popen(
                 argv_helper,
                 env=env, stdout=subproc.PIPE, stderr=subproc.STDOUT) as proc:
-            if Args.verbose and Args.verbose >= 1:
-                for line in proc.stdout:
-                    print(line.decode("utf-8"), end="")
+            if Args.verbose:
+                print_child_output(proc)
     except subproc.CalledProcessError as ex:
         logging.error(
             "Steam Runtime helper exited abnormally:\n%s", ex.output.decode("utf-8"))
@@ -394,8 +393,12 @@ def start_with_wine():
     cmd_str += "\n    ".join(argv)
     logging.info("Running Wine:\n  %s%s", env_str, cmd_str)
     try:
-        output = subproc.check_output(argv, env=env, stderr=subproc.STDOUT)
-        logging.info("Wine output:\n%s", output.decode("utf-8"))
+        with subproc.Popen(
+                argv,
+                env=env, stdout=subproc.PIPE, stderr=subproc.STDOUT) as proc:
+            if Args.verbose:
+                print("Wine output:")
+                print_child_output(proc)
     except subproc.CalledProcessError as ex:
         logging.error("Wine output:\n%s", ex.output.decode("utf-8"))
 

--- a/truckersmp_cli/steamruntime_helper.py
+++ b/truckersmp_cli/steamruntime_helper.py
@@ -49,10 +49,18 @@ def main():
                     env=env_3rdparty, stderr=subproc.STDOUT))
 
     try:
-        output = subproc.check_output(
-            args.game_arguments, env=env, stderr=subproc.STDOUT)
-        if args.verbose is not None:
-            print("Proton output:\n" + output.decode("utf-8"))
+        with subproc.Popen(
+                args.game_arguments,
+                env=env, stdout=subproc.PIPE, stderr=subproc.STDOUT) as proc:
+            if args.verbose:
+                print("Proton output:")
+                for line in proc.stdout:
+                    try:
+                        print(line.decode("utf-8"), end="", flush=True)
+                    except UnicodeDecodeError:
+                        print(
+                            "!! NON UNICODE OUTPUT !!", repr(line),
+                            sep="  ", end="", flush=True)
     except subproc.CalledProcessError as ex:
         print("Proton output:\n" + ex.output.decode("utf-8"), file=sys.stderr)
 

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -432,6 +432,20 @@ def perform_self_update():
     logging.info("Self update complete")
 
 
+def print_child_output(proc):
+    """
+    Print child process output.
+
+    proc: A subprocess.Popen object
+    """
+    for line in proc.stdout:
+        try:
+            print(line.decode("utf-8"), end="", flush=True)
+        except UnicodeDecodeError:
+            print(
+                "!! NON UNICODE OUTPUT !!", repr(line), sep="  ", end="", flush=True)
+
+
 def setup_wine_discord_ipc_bridge():
     """
     Check and download wine-discord-ipc-bridge.


### PR DESCRIPTION
* Read output line by line
* `print()` with `flush=True`
* Add exception handling for `UnicodeDecodeError`