### PR TITLE
GitHub Actions: Get rid of unnecessary actions in "Build truckersmp-cli.exe"

### DIFF
--- a/.github/workflows/build_and_upload_inject_program.yaml
+++ b/.github/workflows/build_and_upload_inject_program.yaml
@@ -27,9 +27,7 @@ jobs:
              sudo apt -q update
              sudo apt -q install --no-install-recommends gcc-mingw-w64-x86-64
       - name: Build truckersmp-cli.exe
-             # we need "make clean" because we already have truckersmp-cli.exe
-             # and "make" does nothing even when truckersmp-cli.c is changed
-        run: make clean && make
+        run: make truckersmp_cli/truckersmp-cli.exe
       - name: Strip truckersmp-cli.exe
         run: x86_64-w64-mingw32-strip truckersmp_cli/truckersmp-cli.exe
       - uses: actions/upload-artifact@v1


### PR DESCRIPTION
* `make clean` is now unnecessary because we removed `truckersmp-cli.exe` in #78 (Release 0.1.0)
* No need to generate completion files in the job

Partially written by @Lucki (https://github.com/truckersmp-cli/truckersmp-cli/pull/179#issuecomment-833514751).