### PR TITLE
Allow to parse configuration file for third-party programs and start the programs

### DIFF
--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -36,20 +36,6 @@ def check_args_errors():
     """Check command-line arguments."""
     # pylint: disable=too-many-branches,too-many-statements
 
-    # warn if using deprecated options
-    if Args.ets2:
-        logging.warning("'--ets2' ('-e') option is deprecated, use new syntax instead")
-    if Args.ats:
-        logging.warning("'--ats' ('-a') option is deprecated, use new syntax instead")
-    if Args.update:
-        logging.warning("'--update' ('-u') option is deprecated, use new syntax instead")
-    if Args.downgrade:
-        logging.warning("'--downgrade' option is deprecated, use new syntax instead")
-    if Args.start:
-        logging.warning("'--start' ('-s') option is deprecated, use new syntax instead")
-    if Args.singleplayer:
-        logging.warning("'--singleplayer' option is deprecated, use new syntax instead")
-
     # "--downgrade" implies "--update"
     if Args.downgrade:
         Args.update = True
@@ -383,6 +369,20 @@ def process_actions_gamenames():
 
     This function must be called after parse_args(namespace=Args)
     """
+    # warn if using deprecated options
+    if Args.ets2:
+        logging.warning("'--ets2' ('-e') option is deprecated, use new syntax instead")
+    if Args.ats:
+        logging.warning("'--ats' ('-a') option is deprecated, use new syntax instead")
+    if Args.update:
+        logging.warning("'--update' ('-u') option is deprecated, use new syntax instead")
+    if Args.downgrade:
+        logging.warning("'--downgrade' option is deprecated, use new syntax instead")
+    if Args.start:
+        logging.warning("'--start' ('-s') option is deprecated, use new syntax instead")
+    if Args.singleplayer:
+        logging.warning("'--singleplayer' option is deprecated, use new syntax instead")
+
     # actions
     if Args.action == "start":
         Args.start = True

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -50,28 +50,6 @@ def check_args_errors():
     if Args.singleplayer:
         logging.warning("'--singleplayer' option is deprecated, use new syntax instead")
 
-    # check actions in new syntax
-    if Args.action == "start":
-        Args.start = True
-    elif Args.action == "update":
-        Args.update = True
-    elif Args.action == "downgrade":
-        Args.downgrade = True
-    elif Args.action == "updateandstart" or Args.action == "ustart":
-        Args.update = Args.start = True
-    elif Args.action == "downgradeandstart" or Args.action == "dstart":
-        Args.downgrade = Args.start = True
-
-    # check game names in new syntax
-    if Args.game == "ets2mp":
-        Args.ets2 = True
-    elif Args.game == "atsmp":
-        Args.ats = True
-    elif Args.game == "ets2":
-        Args.ets2 = Args.singleplayer = True
-    elif Args.game == "ats":
-        Args.ats = Args.singleplayer = True
-
     # "--downgrade" implies "--update"
     if Args.downgrade:
         Args.update = True
@@ -397,3 +375,32 @@ SteamCMD can use your saved credentials for convenience.
         nargs="?")
 
     return parser, store_actions
+
+
+def process_actions_gamenames():
+    """
+    Process actions/game names in the new syntax.
+
+    This function must be called after parse_args(namespace=Args)
+    """
+    # actions
+    if Args.action == "start":
+        Args.start = True
+    elif Args.action == "update":
+        Args.update = True
+    elif Args.action == "downgrade":
+        Args.downgrade = True
+    elif Args.action == "updateandstart" or Args.action == "ustart":
+        Args.update = Args.start = True
+    elif Args.action == "downgradeandstart" or Args.action == "dstart":
+        Args.downgrade = Args.start = True
+
+    # game names
+    if Args.game == "ets2mp":
+        Args.ets2 = True
+    elif Args.game == "atsmp":
+        Args.ats = True
+    elif Args.game == "ets2":
+        Args.ets2 = Args.singleplayer = True
+    elif Args.game == "ats":
+        Args.ats = Args.singleplayer = True

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -372,8 +372,13 @@ def process_actions_gamenames():
     # warn if using deprecated options
     if Args.ets2:
         logging.warning("'--ets2' ('-e') option is deprecated, use new syntax instead")
+        # the game name (Args.game) will be used when parsing configuration file
+        if Args.game == "none":
+            Args.game = "ets2" if Args.singleplayer else "ets2mp"
     if Args.ats:
         logging.warning("'--ats' ('-a') option is deprecated, use new syntax instead")
+        if Args.game == "none":
+            Args.game = "ats" if Args.singleplayer else "atsmp"
     if Args.update:
         logging.warning("'--update' ('-u') option is deprecated, use new syntax instead")
     if Args.downgrade:

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -11,7 +11,7 @@ import platform
 import sys
 
 from .utils import VDF_IS_AVAILABLE, get_current_steam_user
-from .variables import AppId, Args, Dir
+from .variables import AppId, Args, Dir, File
 
 
 ACTIONS = (
@@ -180,6 +180,7 @@ def create_arg_parser():
     * The 2nd element is a list of _StoreAction objects
       (used only in "gen_completions" program)
     """
+    # pylint: disable=too-many-statements
     desc = """
 A simple launcher for TruckersMP to play ATS or ETS2 in multiplayer.
 
@@ -217,6 +218,11 @@ SteamCMD can use your saved credentials for convenience.
         "-b", "--beta", metavar="VERSION", type=str,
         help="""set game version to VERSION,
                 useful for downgrading (e.g. "temporary_1_35")"""))
+    store_actions.append(parser.add_argument(
+        "-c", "--configfile", metavar="FILE",
+        default=File.default_configfile,
+        help="""use alternative configuration file
+                [Default: $XDG_CONFIG_HOME/truckersmp-cli/truckersmp-cli.conf]"""))
     store_actions.append(parser.add_argument(
         "-d", "--enable-d3d11",
         help="use Direct3D 11 instead of OpenGL",

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -369,6 +369,8 @@ def process_actions_gamenames():
 
     This function must be called after parse_args(namespace=Args)
     """
+    # pylint: disable=too-many-branches
+
     # warn if using deprecated options
     if Args.ets2:
         logging.warning("'--ets2' ('-e') option is deprecated, use new syntax instead")

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -20,7 +20,6 @@ class ConfigFile:
 
         configfile: Path to configuration file
         """
-        # pylint: disable=too-many-branches
         self._thirdparty_wait = 0
         self._thirdparty_executables = []
         parser = configparser.ConfigParser()
@@ -35,28 +34,9 @@ class ConfigFile:
             #   [thirdparty.ets2.prog1]   -> ETS2
             #   [thirdparty.atsmp.prog1]  -> ATSMP
             #   [thirdparty.ats.prog1]    -> ATS
-            if Args.singleplayer:
-                if Args.ets2:  # ets2
-                    if (sect.startswith("thirdparty.ets2mp.")
-                            or sect.startswith("thirdparty.ats.")
-                            or sect.startswith("thirdparty.atsmp.")):
-                        continue
-                else:          # ats
-                    if (sect.startswith("thirdparty.ets2mp.")
-                            or sect.startswith("thirdparty.ets2.")
-                            or sect.startswith("thirdparty.atsmp.")):
-                        continue
-            else:
-                if Args.ets2:  # ets2mp
-                    if (sect.startswith("thirdparty.ets2.")
-                            or sect.startswith("thirdparty.ats.")
-                            or sect.startswith("thirdparty.atsmp.")):
-                        continue
-                else:          # atsmp
-                    if (sect.startswith("thirdparty.ets2mp.")
-                            or sect.startswith("thirdparty.ets2.")
-                            or sect.startswith("thirdparty.ats.")):
-                        continue
+            if (sect.count(".") == 2
+                    and not sect.startswith("thirdparty." + Args.game + ".")):
+                continue
             try:
                 wait = int(parser[sect]["wait"])
             except (KeyError, ValueError):

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -17,7 +17,7 @@ class ConfigFile:
 
         configfile: Path to configuration file
         """
-        self._thirdparty_total_wait = 0
+        self._thirdparty_wait = 0
         self._thirdparty_executables = []
         parser = configparser.ConfigParser()
         parser.read(configfile)
@@ -27,9 +27,9 @@ class ConfigFile:
                 continue
             try:
                 wait = int(parser[sect]["wait"])
-                self._thirdparty_total_wait += wait
             except (KeyError, ValueError):
                 wait = 0  # invalid or missing
+            self._thirdparty_wait = max(wait, self._thirdparty_wait)
             self._thirdparty_executables.append(
                 os.path.expanduser(parser[sect]["executable"]))
 
@@ -41,4 +41,4 @@ class ConfigFile:
     @property
     def thirdparty_total_wait(self):
         """Total waiting time for third-party programs."""
-        return self._thirdparty_total_wait
+        return self._thirdparty_wait

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -1,0 +1,44 @@
+"""
+Configuration file handler for truckersmp-cli main script.
+
+Licensed under MIT.
+"""
+
+import configparser
+import os
+
+
+class ConfigFile:
+    """Configuration file."""
+
+    def __init__(self, configfile):
+        """
+        Initialize ConfigFile object.
+
+        configfile: Path to configuration file
+        """
+        self._thirdparty_total_wait = 0
+        self._thirdparty_executables = []
+        parser = configparser.ConfigParser()
+        parser.read(configfile)
+        for sect in parser.sections():
+            # get data from valid thirdparty.* sections
+            if not sect.startswith("thirdparty.") or "executable" not in parser[sect]:
+                continue
+            try:
+                wait = int(parser[sect]["wait"])
+                self._thirdparty_total_wait += wait
+            except (KeyError, ValueError):
+                wait = 0  # invalid or missing
+            self._thirdparty_executables.append(
+                os.path.expanduser(parser[sect]["executable"]))
+
+    @property
+    def thirdparty_executables(self):
+        """Sections for third-party programs."""
+        return self._thirdparty_executables
+
+    @property
+    def thirdparty_total_wait(self):
+        """Total waiting time for third-party programs."""
+        return self._thirdparty_total_wait

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -5,7 +5,6 @@ Licensed under MIT.
 """
 
 import configparser
-import os
 
 
 class ConfigFile:
@@ -30,8 +29,7 @@ class ConfigFile:
             except (KeyError, ValueError):
                 wait = 0  # invalid or missing
             self._thirdparty_wait = max(wait, self._thirdparty_wait)
-            self._thirdparty_executables.append(
-                os.path.expanduser(parser[sect]["executable"]))
+            self._thirdparty_executables.append(parser[sect]["executable"])
 
     @property
     def thirdparty_executables(self):

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -57,10 +57,10 @@ class ConfigFile:
 
     @property
     def thirdparty_executables(self):
-        """Sections for third-party programs."""
+        """Rerurn third-party programs paths."""
         return self._thirdparty_executables
 
     @property
-    def thirdparty_total_wait(self):
-        """Total waiting time for third-party programs."""
+    def thirdparty_wait(self):
+        """Rerurn waiting time for third-party programs."""
         return self._thirdparty_wait

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -5,6 +5,10 @@ Licensed under MIT.
 """
 
 import configparser
+import os
+
+from .utils import is_dos_style_abspath
+from .variables import Dir
 
 
 class ConfigFile:
@@ -29,7 +33,18 @@ class ConfigFile:
             except (KeyError, ValueError):
                 wait = 0  # invalid or missing
             self._thirdparty_wait = max(wait, self._thirdparty_wait)
-            self._thirdparty_executables.append(parser[sect]["executable"])
+            exe_path = parser[sect]["executable"]
+            if os.path.isabs(exe_path):
+                # absolute path: use the given path
+                self._thirdparty_executables.append(exe_path)
+            else:
+                if is_dos_style_abspath(exe_path):
+                    # DOS/Windows style absolute path: use the given path
+                    self._thirdparty_executables.append(exe_path)
+                else:
+                    # relative path: assume it's relative to our data directory
+                    self._thirdparty_executables.append(
+                        os.path.join(Dir.truckersmp_cli_data, exe_path))
 
     @property
     def thirdparty_executables(self):

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -8,7 +8,7 @@ import configparser
 import os
 
 from .utils import is_dos_style_abspath
-from .variables import Dir
+from .variables import Args, Dir
 
 
 class ConfigFile:
@@ -20,6 +20,7 @@ class ConfigFile:
 
         configfile: Path to configuration file
         """
+        # pylint: disable=too-many-branches
         self._thirdparty_wait = 0
         self._thirdparty_executables = []
         parser = configparser.ConfigParser()
@@ -28,6 +29,34 @@ class ConfigFile:
             # get data from valid thirdparty.* sections
             if not sect.startswith("thirdparty.") or "executable" not in parser[sect]:
                 continue
+            # only use configurations for the specified game
+            #   [thirdparty.prog1]        -> all games
+            #   [thirdparty.ets2mp.prog1] -> ETS2MP
+            #   [thirdparty.ets2.prog1]   -> ETS2
+            #   [thirdparty.atsmp.prog1]  -> ATSMP
+            #   [thirdparty.ats.prog1]    -> ATS
+            if Args.singleplayer:
+                if Args.ets2:  # ets2
+                    if (sect.startswith("thirdparty.ets2mp.")
+                            or sect.startswith("thirdparty.ats.")
+                            or sect.startswith("thirdparty.atsmp.")):
+                        continue
+                else:          # ats
+                    if (sect.startswith("thirdparty.ets2mp.")
+                            or sect.startswith("thirdparty.ets2.")
+                            or sect.startswith("thirdparty.atsmp.")):
+                        continue
+            else:
+                if Args.ets2:  # ets2mp
+                    if (sect.startswith("thirdparty.ets2.")
+                            or sect.startswith("thirdparty.ats.")
+                            or sect.startswith("thirdparty.atsmp.")):
+                        continue
+                else:          # atsmp
+                    if (sect.startswith("thirdparty.ets2mp.")
+                            or sect.startswith("thirdparty.ets2.")
+                            or sect.startswith("thirdparty.ats.")):
+                        continue
             try:
                 wait = int(parser[sect]["wait"])
             except (KeyError, ValueError):

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -57,10 +57,10 @@ class ConfigFile:
 
     @property
     def thirdparty_executables(self):
-        """Rerurn third-party programs paths."""
+        """Return third-party program paths."""
         return self._thirdparty_executables
 
     @property
     def thirdparty_wait(self):
-        """Rerurn waiting time for third-party programs."""
+        """Return waiting time for third-party programs."""
         return self._thirdparty_wait

--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -12,8 +12,10 @@ import signal
 import subprocess as subproc
 import sys
 import tempfile
+import time
 
 from .args import check_args_errors, create_arg_parser
+from .configfile import ConfigFile
 from .steamcmd import update_game
 from .truckersmp import update_mod
 from .utils import (
@@ -95,6 +97,9 @@ def main():
     # parse options
     arg_parser = create_arg_parser()[0]
     arg_parser.parse_args(namespace=Args)
+
+    # load configuration file
+    cfg = ConfigFile(Args.configfile)
 
     # print version
     if Args.version:
@@ -179,7 +184,7 @@ the "var" subdirectory must be writable""".format(Args.steamruntimedir))
         i = 0 if Args.proton else 1
         compat_tool, start_game = start_functions[i]
         logging.debug("Starting game with %s", compat_tool)
-        start_game()
+        start_game(cfg)
 
     sys.exit()
 
@@ -203,8 +208,12 @@ def setup_logging():
         logger.addHandler(file_handler)
 
 
-def start_with_proton():
-    """Start game with Proton."""
+def start_with_proton(cfg):
+    """
+    Start game with Proton.
+
+    cfg: A ConfigFile object
+    """
     # pylint: disable=consider-using-with,too-many-branches
     # pylint: disable=too-many-locals,too-many-statements
     steamdir = wait_for_steam(use_proton=True, loginvdf_paths=File.loginusers_paths)
@@ -358,6 +367,9 @@ def start_with_proton():
             # don't start wine-discord-ipc-bridge when no Discord sockets found
             and len(discord_sockets) > 0):
         argv_helper += ["--executable", File.ipcbridge]
+    for executable in cfg.thirdparty_executables:
+        argv_helper += ["--executable", executable]
+    argv_helper += ["--wait-before-start", str(cfg.thirdparty_total_wait)]
     if Args.verbose:
         argv_helper.append("-v" if Args.verbose == 1 else "-vv")
     argv_helper += ["--", ] + proton_args
@@ -385,9 +397,13 @@ def start_with_proton():
         set_wine_desktop_registry(prefix, wine, False)
 
 
-def start_with_wine():
-    """Start game with Wine."""
-    # pylint: disable=consider-using-with,too-many-branches
+def start_with_wine(cfg):
+    """
+    Start game with Wine.
+
+    cfg: A ConfigFile object
+    """
+    # pylint: disable=consider-using-with,too-many-branches,too-many-locals
     wine = os.environ["WINE"] if "WINE" in os.environ else "wine"
     argv = [wine, ]
     if (Args.activate_native_d3dcompiler_47
@@ -408,13 +424,16 @@ def start_with_wine():
         env=env,
     )
 
-    ipcbr_proc = None
+    executables = cfg.thirdparty_executables.copy()
     if not Args.singleplayer and not Args.without_wine_discord_ipc_bridge:
-        ipcbr_path = setup_wine_discord_ipc_bridge()
-        logging.info("Starting wine-discord-ipc-bridge")
-        ipcbr_proc = subproc.Popen(
-            argv + [ipcbr_path, ],
-            env=env, stdout=subproc.DEVNULL, stderr=subproc.DEVNULL)
+        executables.append(setup_wine_discord_ipc_bridge())
+
+    thirdparty_processes = []
+    for path in executables:
+        thirdparty_processes.append(
+            subproc.Popen([wine, ] + [path, ], env=env, stderr=subproc.STDOUT))
+
+    time.sleep(cfg.thirdparty_total_wait)
 
     if "WINEDLLOVERRIDES" not in env:
         env["WINEDLLOVERRIDES"] = ""
@@ -452,7 +471,7 @@ def start_with_wine():
     except subproc.CalledProcessError as ex:
         logging.error("Wine output:\n%s", ex.output.decode("utf-8"))
 
-    if ipcbr_proc:
-        if ipcbr_proc.poll() is None:
-            ipcbr_proc.kill()
-        ipcbr_proc.wait()
+    for proc in thirdparty_processes:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait()

--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 import time
 
-from .args import check_args_errors, create_arg_parser
+from .args import check_args_errors, create_arg_parser, process_actions_gamenames
 from .configfile import ConfigFile
 from .steamcmd import update_game
 from .truckersmp import update_mod
@@ -97,6 +97,7 @@ def main():
     # parse options
     arg_parser = create_arg_parser()[0]
     arg_parser.parse_args(namespace=Args)
+    process_actions_gamenames()
 
     # load configuration file
     cfg = ConfigFile(Args.configfile)

--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -370,7 +370,7 @@ def start_with_proton(cfg):
         argv_helper += ["--executable", File.ipcbridge]
     for executable in cfg.thirdparty_executables:
         argv_helper += ["--executable", executable]
-    argv_helper += ["--wait-before-start", str(cfg.thirdparty_total_wait)]
+    argv_helper += ["--wait-before-start", str(cfg.thirdparty_wait)]
     if Args.verbose:
         argv_helper.append("-v" if Args.verbose == 1 else "-vv")
     argv_helper += ["--", ] + proton_args
@@ -434,7 +434,7 @@ def start_with_wine(cfg):
         thirdparty_processes.append(
             subproc.Popen([wine, ] + [path, ], env=env, stderr=subproc.STDOUT))
 
-    time.sleep(cfg.thirdparty_total_wait)
+    time.sleep(cfg.thirdparty_wait)
 
     if "WINEDLLOVERRIDES" not in env:
         env["WINEDLLOVERRIDES"] = ""

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -475,6 +475,21 @@ def is_d3dcompiler_setup_skippable():
                 and ver_proton["minor"] >= ver_pfx["minor"]))
 
 
+def is_dos_style_abspath(path):
+    """
+    Check whether the given path is a DOS/Windows style absolute path.
+
+    path: A path string
+    """
+    if len(path) < 3:
+        return False
+    drv = path[0]  # drive letter
+    # A:65, B:66, ... Z:90, a:97, b:98, ... z:122
+    if ord(drv) < 65 or (ord(drv) > 90 and ord(drv) < 97) or ord(drv) > 122:
+        return False
+    return path[1:3] == ":\\"
+
+
 def is_envar_enabled(envars, name):
     """
     Check whether the specified environment variable is enabled.

--- a/truckersmp_cli/variables.py
+++ b/truckersmp_cli/variables.py
@@ -27,6 +27,7 @@ class Args:
 class Dir:
     """Directories."""
 
+    XDG_CONFIG_HOME = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
     XDG_DATA_HOME = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
     truckersmp_cli_data = os.path.join(XDG_DATA_HOME, "truckersmp-cli")
     default_gamedir = dict(
@@ -63,6 +64,8 @@ class File:
         # Debian-based systems, new path
         os.path.join(os.path.expanduser("~/.steam/debian-installation"), loginvdf_inner),
     ]
+    default_configfile = os.path.join(
+        Dir.XDG_CONFIG_HOME, "truckersmp-cli/truckersmp-cli.conf")
     proton_json = os.path.join(Dir.scriptdir, "proton.json")
     steamruntime_json = os.path.join(Dir.scriptdir, "steamruntime.json")
     inject_exe = os.path.join(Dir.scriptdir, "truckersmp-cli.exe")


### PR DESCRIPTION
For part of #103.

This PR allows users to start *already installed* TrucksBook Client (`TB Client.exe`) and other third-party programs.
* *No automated setup for TrucksBook in this PR*
* ~~If `C:\Program Files (x86)\TrucksBook Client\TB Client.exe` is present and readable, `truckersmp-cli` automatically start it before the game~~
* ~~If `--without-trucksbook` is given, `truckersmp-cli` doesn't start it~~
* ~~According to https://github.com/truckersmp-cli/truckersmp-cli/pull/159#issuecomment-841293257, TrucksBook needs sleep -> The default is 60 seconds (can be changed by `--sleep-before-start` option)~~
* Users of third-party programs need to write valid configuration (see the example below)
* Users can specify alternative configuration file (the default is `$XDG_CONFIG_HOME/truckersmp-cli/truckersmp-cli.conf`) by using `-c`/`--configfile` option

An example for TrucksBook users:
```
# Section name must start with "thirdparty."
[thirdparty.trucksbook]
# Path to TB Client.exe (Required)
executable = ~/.local/share/truckersmp-cli/Euro Truck Simulator 2/prefix/pfx/dosdevices/c:/Program Files (x86)/TrucksBook Client/TB Client.exe
# Waiting time before starting game (Optional, default:0)
# Actual waiting time is the maximum value of all thirdparty.* sections
wait = 45
```