### PR TITLE
activate_native_d3dcompiler_47(): Use "dosdevices/c:" instead of "drive_c"

### DIFF
--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -58,7 +58,7 @@ def activate_native_d3dcompiler_47(prefix, wine):
             sys.exit("Failed to download d3dcompiler_47.dll")
 
     # copy into system32
-    destdir = os.path.join(prefix, "drive_c/windows/system32")
+    destdir = os.path.join(prefix, Dir.system32_inner)
     logging.debug("Copying d3dcompiler_47.dll into %s", destdir)
     shutil.copy(File.d3dcompiler_47, destdir)
 

--- a/truckersmp_cli/variables.py
+++ b/truckersmp_cli/variables.py
@@ -45,6 +45,7 @@ class Dir:
     dllsdir = os.path.join(truckersmp_cli_data, "dlls")
     ipcbrdir = os.path.join(truckersmp_cli_data, "wine-discord-ipc-bridge")
     scriptdir = os.path.dirname(os.path.realpath(__file__))
+    system32_inner = "dosdevices/c:/windows/system32"
 
 
 class File:


### PR DESCRIPTION
`/path/to/prefix/dosdevices/[drive letter]:` path is actually used by Wine/Proton. `drive_c` is just the default directory name for the automatically created OS drive.