### PR TITLE
Use native d3dcompiler_47.dll by default when using D3D11

### DIFF
--- a/truckersmp_cli/variables.py
+++ b/truckersmp_cli/variables.py
@@ -68,6 +68,7 @@ class File:
     inject_exe = os.path.join(Dir.scriptdir, "truckersmp-cli.exe")
     overlayrenderer_inner = "ubuntu12_64/gameoverlayrenderer.so"
     d3dcompiler_47 = os.path.join(Dir.dllsdir, "d3dcompiler_47.dll")
+    d3dcompiler_47_inner = os.path.join(Dir.system32_inner, "d3dcompiler_47.dll")
     d3dcompiler_47_md5 = "b2cc65e1930e75f563078c6a20221b37"
     ipcbridge = os.path.join(Dir.ipcbrdir, "winediscordipcbridge.exe")
     ipcbridge_md5 = "78fef85810c5bb8e492d3f67f48947a5"


### PR DESCRIPTION
I sent a Wine bug report "[TruckersMP: Multiplayer overlay is invisible when builtin d3dcompiler_47.dll is used](https://bugs.winehq.org/show_bug.cgi?id=50777)" in March 2021 but nothing changed as of June 2021.

I guess that it's quite difficult to fix that (= to implement something missing in Wine's builtin DLL?).

So I think that we should use the native version of `d3dcompiler_47.dll` by default.

## Purpose

This PR allows D3D11 users to omit `--activate-native-d3dcompiler-47` by checking whether `truckersmp-cli` needs to call `activate_native_d3dcompiler_47()`.

## Behavior

* If `--activate-native-d3dcompiler-47` is given, `activate_native_d3dcompiler_47()` is always called (multiplayer and singleplayer)
* If `--activate-native-d3dcompiler-47` is not given, `activate_native_d3dcompiler_47()` is called only when *starting multiplayer + D3D11 is used + the prefix is not downgraded*

## Proton prefix version comparison

If Proton version (`CURRENT_PREFIX_VERSION` in the `proton` script) is equal to prefix version (the content of `[proton prefix]/version`) or newer than the prefix version, Proton doesn't downgrade the prefix: No need to call `activate_native_d3dcompiler_47()` automatically.

If Proton version is older than prefix version, Proton downgrades the prefix: `activate_native_d3dcompiler_47()` needs to be called.