### PR TITLE
Add functionality to use wine-discord-ipc-bridge when running the game in singleplayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Short option|Long option|Description
 (Not available)|`--wine-steam-dir`|Choose a directory for Windows version of Steam [Default: `C:\Program Files (x86)\Steam` in the prefix]
 (Not available)|`--without-steam-runtime`|Don't use Steam Runtime even when using Proton 5.13 or newer
 (Not available)|`--without-wine-discord-ipc-bridge`|Don't use wine-discord-ipc-bridge for Discord Rich Presence
+(Not available)|`--singleplayer-wine-discord-ipc-bridge`|Use wine-discord-ipc-bridge when starting game in singleplayer
 (Not available)|`--version`|Print version information and quit
 
 ### Proton versions and AppIDs

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -362,6 +362,10 @@ SteamCMD can use your saved credentials for convenience.
         help="don't use wine-discord-ipc-bridge for Discord Rich Presence",
         action="store_true"))
     store_actions.append(parser.add_argument(
+        "--singleplayer-wine-discord-ipc-bridge",
+        help="starts wine-discord-ipc-bridge when starting game in singleplayer",
+        action="store_true"))
+    store_actions.append(parser.add_argument(
         "--version",
         help="""print version information and quit""",
         action="store_true"))

--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -351,6 +351,10 @@ def start_with_proton():
     if (not Args.singleplayer
             and not Args.without_wine_discord_ipc_bridge
             # don't start wine-discord-ipc-bridge when no Discord sockets found
+            and len(discord_sockets) > 0
+        or Args.singleplayer
+            and Args.singleplayer_wine_discord_ipc_bridge
+            # don't start wine-discord-ipc-bridge when no Discord sockets found
             and len(discord_sockets) > 0):
         argv_helper += ["--executable", File.ipcbridge]
     if Args.verbose:


### PR DESCRIPTION
Decided to fix my own issue ( #203 ). I added the --singleplayer-wine-discord-ipc-bridge argument that runs winediscordipcbridge.exe alongside the game when starting it in singleplayer (`truckersmp-cli ets2`), in the same way as it does when starting the game in multiplayer (`truckersmp-cli ets2mp`).