### PR TITLE
main.py, utils.py: Use an external function for printing environment variables and command line

### DIFF
--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -19,7 +19,7 @@ from .truckersmp import update_mod
 from .utils import (
     activate_native_d3dcompiler_47, check_libsdl2, find_discord_ipc_sockets,
     get_proton_version, get_steam_library_dirs, is_d3dcompiler_setup_skippable,
-    perform_self_update, print_child_output,
+    log_info_formatted_envars_and_args, perform_self_update, print_child_output,
     set_wine_desktop_registry, setup_wine_discord_ipc_bridge, wait_for_steam,
 )
 from .variables import AppId, Args, Dir, File, URL
@@ -362,19 +362,11 @@ def start_with_proton():
         argv_helper.append("-v" if Args.verbose == 1 else "-vv")
     argv_helper += ["--", ] + proton_args
 
-    def log_info_formatted_envars():
-        nonlocal env_print
-        nonlocal env
-        nonlocal proton_args
-        env_str = ""
-        cmd_str = ""
-        name_value_pairs = []
-        for name in env_print:
-            name_value_pairs.append("{}={}".format(name, env[name]))
-        env_str += "\n  ".join(name_value_pairs) + "\n  "
-        cmd_str += "\n    ".join(proton_args)
-        logging.info("Running Steam Runtime helper:\n  %s%s", env_str, cmd_str)
-    log_info_formatted_envars()
+    log_info_formatted_envars_and_args(
+        runner="Steam Runtime helper",
+        env_print=env_print,
+        env=env,
+        args=proton_args)
     try:
         with subproc.Popen(
                 argv_helper,
@@ -439,18 +431,11 @@ def start_with_wine():
         if opt != "":
             argv.append(opt)
 
-    def log_info_formatted_envars():
-        nonlocal argv
-        nonlocal env
-        env_str = ""
-        cmd_str = ""
-        name_value_pairs = []
-        for name in ("WINEARCH", "WINEDEBUG", "WINEDLLOVERRIDES", "WINEPREFIX"):
-            name_value_pairs.append("{}={}".format(name, env[name]))
-        env_str += "\n  ".join(name_value_pairs) + "\n  "
-        cmd_str += "\n    ".join(argv)
-        logging.info("Running Wine:\n  %s%s", env_str, cmd_str)
-    log_info_formatted_envars()
+    log_info_formatted_envars_and_args(
+        runner="Wine",
+        env_print=("WINEARCH", "WINEDEBUG", "WINEDLLOVERRIDES", "WINEPREFIX"),
+        env=env,
+        args=argv)
     try:
         with subproc.Popen(
                 argv,

--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -362,14 +362,19 @@ def start_with_proton():
         argv_helper.append("-v" if Args.verbose == 1 else "-vv")
     argv_helper += ["--", ] + proton_args
 
-    env_str = ""
-    cmd_str = ""
-    name_value_pairs = []
-    for name in env_print:
-        name_value_pairs.append("{}={}".format(name, env[name]))
-    env_str += "\n  ".join(name_value_pairs) + "\n  "
-    cmd_str += "\n    ".join(proton_args)
-    logging.info("Running Steam Runtime helper:\n  %s%s", env_str, cmd_str)
+    def log_info_formatted_envars():
+        nonlocal env_print
+        nonlocal env
+        nonlocal proton_args
+        env_str = ""
+        cmd_str = ""
+        name_value_pairs = []
+        for name in env_print:
+            name_value_pairs.append("{}={}".format(name, env[name]))
+        env_str += "\n  ".join(name_value_pairs) + "\n  "
+        cmd_str += "\n    ".join(proton_args)
+        logging.info("Running Steam Runtime helper:\n  %s%s", env_str, cmd_str)
+    log_info_formatted_envars()
     try:
         with subproc.Popen(
                 argv_helper,
@@ -434,14 +439,18 @@ def start_with_wine():
         if opt != "":
             argv.append(opt)
 
-    env_str = ""
-    cmd_str = ""
-    name_value_pairs = []
-    for name in ("WINEARCH", "WINEDEBUG", "WINEDLLOVERRIDES", "WINEPREFIX"):
-        name_value_pairs.append("{}={}".format(name, env[name]))
-    env_str += "\n  ".join(name_value_pairs) + "\n  "
-    cmd_str += "\n    ".join(argv)
-    logging.info("Running Wine:\n  %s%s", env_str, cmd_str)
+    def log_info_formatted_envars():
+        nonlocal argv
+        nonlocal env
+        env_str = ""
+        cmd_str = ""
+        name_value_pairs = []
+        for name in ("WINEARCH", "WINEDEBUG", "WINEDLLOVERRIDES", "WINEPREFIX"):
+            name_value_pairs.append("{}={}".format(name, env[name]))
+        env_str += "\n  ".join(name_value_pairs) + "\n  "
+        cmd_str += "\n    ".join(argv)
+        logging.info("Running Wine:\n  %s%s", env_str, cmd_str)
+    log_info_formatted_envars()
     try:
         with subproc.Popen(
                 argv,

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -490,6 +490,25 @@ def is_envar_enabled(envars, name):
     return len(value) > 0 and value != "0"
 
 
+def log_info_formatted_envars_and_args(runner, env_print, env, args):
+    """
+    Print formatted envars and command line with logging level "info".
+
+    runner: "Steam Runtime helper" or "Wine"
+    env_print: Environment variable names to print
+    env: A dict of environment variables
+    args: Command line
+    """
+    env_str = ""
+    cmd_str = ""
+    name_value_pairs = []
+    for name in env_print:
+        name_value_pairs.append("{}={}".format(name, env[name]))
+    env_str += "\n  ".join(name_value_pairs) + "\n  "
+    cmd_str += "\n    ".join(args)
+    logging.info("Running %s:\n  %s%s", runner, env_str, cmd_str)
+
+
 def perform_self_update():
     """
     Update files to latest release. Do nothing for Python package.


### PR DESCRIPTION
This also reduces the number of local variables in `start_with_{proton,wine}()`.