### PR TITLE
Allow to start wine-discord-ipc-bridge before starting third-party programs when the user wants

### DIFF
--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -92,8 +92,14 @@ def main():
     arg_parser.parse_args(namespace=Args)
     process_actions_gamenames()
 
+    # set up logging
+    setup_logging()
+
     # load configuration file
-    cfg = ConfigFile(Args.configfile)
+    try:
+        cfg = ConfigFile(Args.configfile)
+    except ValueError as ex:
+        sys.exit("Invalid configuration found in {}:\n{}".format(Args.configfile, ex))
 
     # print version
     if Args.version:
@@ -115,9 +121,6 @@ Try one of the following:
 
 See {} for additional information.""".format(
             File.inject_exe, URL.project_releases, Dir.scriptdir, URL.project_doc_inst))
-
-    # set up logging
-    setup_logging()
 
     # self update
     if Args.self_update:

--- a/truckersmp_cli/steamruntime_helper.py
+++ b/truckersmp_cli/steamruntime_helper.py
@@ -14,6 +14,27 @@ import sys
 import time
 
 
+def start_thirdparty_programs(executables, proton_run):
+    """
+    Start third-party programs.
+
+    This function starts specified third-party programs in the given list
+    and returns a list of subprocess.Popen objects.
+
+    executables: A list of executables
+    proton_run: ["python3" command, Path to "proton" command, "run"]
+    """
+    # pylint: disable=consider-using-with
+    thirdparty_processes = []
+    env = os.environ.copy()
+    if "LD_PRELOAD" in env:
+        del env["LD_PRELOAD"]
+    for path in executables:
+        thirdparty_processes.append(
+            subproc.Popen(proton_run + [path, ], env=env, stderr=subproc.STDOUT))
+    return thirdparty_processes
+
+
 def main():
     """Start truckersmp-cli.exe and optionally 3rd party programs."""
     # pylint: disable=consider-using-with
@@ -24,6 +45,15 @@ def main():
     arg_parser.add_argument(
         "-v", "--verbose", action="count",
         help="verbose output (none:error, once:info, twice or more:debug)")
+    arg_parser.add_argument(
+        "--early-executable", action="append", metavar="FILE",
+        help="""3rd party executable to start early in Steam Runtime container
+                (can be specified multiple times for multiple files)""")
+    arg_parser.add_argument(
+        "--early-wait-before-start", metavar="SECS", type=int,
+        default=0,
+        help="""wait SECS seconds before starting 3rd party executables
+                specified by --executable [Default: 0]""")
     arg_parser.add_argument(
         "--executable", action="append", metavar="FILE",
         help="""3rd party executable to start in Steam Runtime container
@@ -38,26 +68,23 @@ def main():
     args = arg_parser.parse_args()
 
     if args.verbose is not None and args.verbose > 1:
+        print("Executables (early):", args.early_executable)
         print("Executables:", args.executable)
         print("Game Arguments:", args.game_arguments)
+        print("Waiting time (early):", args.early_wait_before_start)
         print("Waiting time:", args.wait_before_start)
 
-    env = os.environ.copy()
+    early_thirdparty_processes = [] if args.early_executable is None \
+        else start_thirdparty_programs(args.early_executable, args.game_arguments[0:3])
 
-    thirdparty_processes = []
-    if args.executable is not None:
-        env_3rdparty = env.copy()
-        if "LD_PRELOAD" in env_3rdparty:
-            del env_3rdparty["LD_PRELOAD"]
-        for path in args.executable:
-            thirdparty_processes.append(
-                subproc.Popen(
-                    # ["python3", "/path/to/proton", "run"] + ["/path/to/program.exe"]
-                    args.game_arguments[0:3] + [path, ],
-                    env=env_3rdparty, stderr=subproc.STDOUT))
+    time.sleep(args.early_wait_before_start)
+
+    thirdparty_processes = [] if args.executable is None \
+        else start_thirdparty_programs(args.executable, args.game_arguments[0:3])
 
     time.sleep(args.wait_before_start)
 
+    env = os.environ.copy()
     try:
         with subproc.Popen(
                 args.game_arguments,
@@ -74,7 +101,7 @@ def main():
     except subproc.CalledProcessError as ex:
         print("Proton output:\n" + ex.output.decode("utf-8"), file=sys.stderr)
 
-    for proc in thirdparty_processes:
+    for proc in thirdparty_processes + early_thirdparty_processes:
         # make sure 3rd party programs is exited
         if proc.poll() is None:
             proc.kill()

--- a/truckersmp_cli/steamruntime_helper.py
+++ b/truckersmp_cli/steamruntime_helper.py
@@ -22,14 +22,18 @@ def start_thirdparty_programs(executables, proton_run):
     and returns a list of subprocess.Popen objects.
 
     executables: A list of executables
+                 from "--early-executable" or "--executable",
+                 or None when it's omitted
     proton_run: ["python3" command, Path to "proton" command, "run"]
     """
     # pylint: disable=consider-using-with
+    if executables is None:  # nothing to do in this function
+        return []
     thirdparty_processes = []
     env = os.environ.copy()
     if "LD_PRELOAD" in env:
         del env["LD_PRELOAD"]
-    for path in executables:
+    for path in executables:  # assume that "executables" is iterable
         thirdparty_processes.append(
             subproc.Popen(proton_run + [path, ], env=env, stderr=subproc.STDOUT))
     return thirdparty_processes
@@ -74,13 +78,13 @@ def main():
         print("Waiting time (early):", args.early_wait_before_start)
         print("Waiting time:", args.wait_before_start)
 
-    early_thirdparty_processes = [] if args.early_executable is None \
-        else start_thirdparty_programs(args.early_executable, args.game_arguments[0:3])
+    early_thirdparty_processes = start_thirdparty_programs(
+        args.early_executable, args.game_arguments[0:3])
 
     time.sleep(args.early_wait_before_start)
 
-    thirdparty_processes = [] if args.executable is None \
-        else start_thirdparty_programs(args.executable, args.game_arguments[0:3])
+    thirdparty_processes = start_thirdparty_programs(
+        args.executable, args.game_arguments[0:3])
 
     time.sleep(args.wait_before_start)
 


### PR DESCRIPTION
Fixes #203.

Details:
* https://github.com/truckersmp-cli/truckersmp-cli/pull/204#issuecomment-873506092
* https://github.com/truckersmp-cli/truckersmp-cli/pull/204#issuecomment-893443565

Notes:
* As of the first commit, the waiting time after starting `wine-discord-ipc-bridge` is *hardcoded to 5 seconds*
* `--early-executable` and `--early-wait-before-start` options have been added to `steamruntime_helper.py`