### PR TITLE
Allow to specify rendering backend name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Short option|Long option|Description
 `-h`|`--help`|Show help
 `-b VERSION`|`--beta VERSION`|Set game version to VERSION, useful for downgrading (e.g. `temporary_1_35`)
 `-c FILE`|`--configfile FILE`|Use alternative configuration file [Default: `$XDG_CONFIG_HOME/truckersmp-cli/truckersmp-cli.conf`]
-`-d`|`--enable-d3d11`|Use Direct3D 11 instead of OpenGL
+`-d`|`--enable-d3d11`|**DEPRECATED** Use Direct3D 11 instead of OpenGL
 `-g DIR`|`--gamedir DIR`|Choose a different directory for the game files [Default: `$XDG_DATA_HOME/truckersmp-cli/(Game name)/data`]
 `-i APPID`|`--proton-appid APPID`|Choose a different AppID for Proton (Needs an update for changes)
 `-l LOG`|`--logfile LOG`|Write log into LOG, `-vv` option is recommended [Default: Empty string (only stderr)] Note: Messages from Steam/SteamCMD won't be written, only from this script (Game logs are written into `My Documents/{ETS2,ATS}MP/logs/client_*.log`)
@@ -92,6 +92,7 @@ Short option|Long option|Description
 `-n NAME`|`--account NAME`|Steam account name to use
 `-o DIR`|`--protondir DIR`|Choose a different Proton directory [Default: `$XDG_DATA_HOME/truckersmp-cli/Proton`]
 `-p`|`--proton`|Start the game with Proton [Default on Linux if neither Proton or Wine are specified]
+`-r {auto,dx11,gl}`|`--rendering-backend {auto,dx11,gl}`|Choose a rendering backend [Default: `auto` (OpenGL is used when `rendering-backend = ` is not specified for the game in the configuration file)]
 `-v`|`--verbose`|Verbose output (none:error, once:info, twice or more:debug)
 `-w`|`--wine`|Start the game with Wine [Default on other systems if neither Proton or Wine are specified]
 `-x DIR`|`--prefixdir DIR`|Choose a different directory for the prefix [Default: `$XDG_DATA_HOME/truckersmp-cli/(Game name)/prefix`]

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -189,7 +189,7 @@ SteamCMD can use your saved credentials for convenience.
                 [Default: $XDG_CONFIG_HOME/truckersmp-cli/truckersmp-cli.conf]"""))
     store_actions.append(parser.add_argument(
         "-d", "--enable-d3d11",
-        help="use Direct3D 11 instead of OpenGL",
+        help="**DEPRECATED** use Direct3D 11 instead of OpenGL",
         action="store_true"))
     store_actions.append(parser.add_argument(
         "-e", "--ets2",
@@ -235,6 +235,14 @@ SteamCMD can use your saved credentials for convenience.
         help="""start the game with Proton
                 [Default on Linux if neither Proton or Wine are specified] """,
         action="store_true"))
+    store_actions.append(parser.add_argument(
+        "-r", "--rendering-backend",
+        # "dx12" and "vk" / "vulkan" may be added in the future
+        choices=("auto", "dx11", "gl"),
+        default="auto",
+        help="""choose a rendering backend
+                [Default: auto (OpenGL is used when "rendering-backend = " is
+                          not specified for the game in the configuration file)]"""))
     store_actions.append(parser.add_argument(
         "-s", "--start",
         help="""**DEPRECATED** start the game

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -7,6 +7,7 @@ Licensed under MIT.
 import configparser
 import logging
 import os
+from enum import Enum
 
 from .utils import is_dos_style_abspath
 from .variables import Args, Dir
@@ -69,19 +70,9 @@ class ConfigFile:
             ConfigFile.handle_game_specific_settings(parser, wants_rich_presence_cnt)
 
     @staticmethod
-    def format_error(name, ex):
+    def configure_rich_presence(parser, wants_rich_presence_cnt):
         """
-        Get a formatted output string for ValueError.
-
-        name: configuration name
-        ex: A ValueError object
-        """
-        return "  Name: {}\n  Error: {}".format(name, ex)
-
-    @staticmethod
-    def handle_game_specific_settings(parser, wants_rich_presence_cnt):
-        """
-        Handle game specific settings.
+        Determine whether to use wine-discord-ipc-bridge.
 
         parser: A ConfigParser object
         wants_rich_presence_cnt: The number of third-party program sections
@@ -106,6 +97,66 @@ class ConfigFile:
             raise ValueError(
                 ConfigFile.format_error("without-rich-presence", ex)) from ex
 
+    @staticmethod
+    def determine_rendering_backend(parser):
+        """
+        Determine rendering backend.
+
+        parser: A ConfigParser object
+        """
+        config_src = ConfigSource.OPTION
+
+        if Args.enable_d3d11:
+            logging.warning("'--enable-d3d11' ('-d') option is deprecated,"
+                            " use '--rendering-backend dx11 (-r dx11)' instead")
+            Args.rendering_backend = "dx11"
+
+        if Args.rendering_backend == "auto":
+            try:
+                rendering_backend = parser[Args.game].get("rendering-backend")
+                # use OpenGL when "rendering-backend" is not specified
+                # in the game specific section
+                if rendering_backend is None:
+                    Args.rendering_backend = "gl"
+                    config_src = ConfigSource.DEFAULT
+                else:
+                    if rendering_backend not in ("dx11", "gl"):
+                        raise ValueError(
+                            "Invalid value '{}' (Valid values are 'dx11' or 'gl')."
+                            "".format(rendering_backend))
+                    Args.rendering_backend = rendering_backend
+                    config_src = ConfigSource.FILE
+            except ValueError as ex:
+                raise ValueError(
+                    ConfigFile.format_error("rendering-backend", ex)) from ex
+        logging.info(
+            "Rendering backend: %s (%s)", Args.rendering_backend, config_src.value)
+
+    @staticmethod
+    def format_error(name, ex):
+        """
+        Get a formatted output string for ValueError.
+
+        name: configuration name
+        ex: A ValueError object
+        """
+        return "  Name: {}\n  Error: {}".format(name, ex)
+
+    @staticmethod
+    def handle_game_specific_settings(parser, wants_rich_presence_cnt):
+        """
+        Handle game specific settings.
+
+        parser: A ConfigParser object
+        wants_rich_presence_cnt: The number of third-party program sections
+                                 that have "wants-rich-presence = [true]"
+        """
+        # Discord Rich Presence
+        ConfigFile.configure_rich_presence(parser, wants_rich_presence_cnt)
+
+        # rendering backend
+        ConfigFile.determine_rendering_backend(parser)
+
     @property
     def thirdparty_executables(self):
         """Return third-party program paths."""
@@ -115,3 +166,11 @@ class ConfigFile:
     def thirdparty_wait(self):
         """Return waiting time for third-party programs."""
         return self._thirdparty_wait
+
+
+class ConfigSource(Enum):
+    """Source of the configuration."""
+
+    DEFAULT = "Default"
+    OPTION = "Command line option"
+    FILE = "Configuration file"

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -122,7 +122,7 @@ class ConfigFile:
                 else:
                     if rendering_backend not in ("dx11", "gl"):
                         raise ValueError(
-                            "Invalid value '{}' (Valid values are 'dx11' or 'gl')."
+                            "Invalid value '{}' (Valid values are 'dx11' or 'gl')"
                             "".format(rendering_backend))
                     Args.rendering_backend = rendering_backend
                     config_src = ConfigSource.FILE

--- a/truckersmp_cli/gamestarter.py
+++ b/truckersmp_cli/gamestarter.py
@@ -174,7 +174,8 @@ class StarterProton(GameStarterInterface):
             proton_args += Args.gamedir, Args.moddir
 
         # game options
-        for opt in Args.game_options.split(" "):
+        for opt in "-rdevice {} {}".format(
+                Args.rendering_backend, Args.game_options).split(" "):
             if opt != "":
                 proton_args.append(opt)
 
@@ -189,7 +190,6 @@ class StarterProton(GameStarterInterface):
         if "LD_PRELOAD" in env:
             env_print.append("LD_PRELOAD")
         env_print += [
-            "PROTON_NO_D3D11",
             "PROTON_USE_WINED3D",
             "STEAM_COMPAT_CLIENT_INSTALL_PATH",
             "STEAM_COMPAT_DATA_PATH",
@@ -216,7 +216,7 @@ class StarterProton(GameStarterInterface):
 
         do_d3dcompiler_setup = (Args.activate_native_d3dcompiler_47
                                 or (not Args.singleplayer
-                                    and Args.enable_d3d11
+                                    and Args.rendering_backend == "dx11"
                                     and not is_d3dcompiler_setup_skippable()))
         logging.debug("Whether to setup native d3dcompiler_47: %s", do_d3dcompiler_setup)
 
@@ -296,7 +296,6 @@ class StarterProton(GameStarterInterface):
             SteamAppId=Args.steamid,
             SteamGameId=Args.steamid,
             PROTON_USE_WINED3D="1" if Args.use_wined3d else "0",
-            PROTON_NO_D3D11="1" if not Args.enable_d3d11 else "0",
         )
 
     @property
@@ -336,7 +335,7 @@ class StarterWine(GameStarterInterface):
 
         if (Args.activate_native_d3dcompiler_47
                 or (not Args.singleplayer
-                    and Args.enable_d3d11
+                    and Args.rendering_backend == "dx11"
                     and not is_d3dcompiler_setup_skippable())):
             activate_native_d3dcompiler_47(Args.prefixdir, wine_args)
 
@@ -367,12 +366,11 @@ class StarterWine(GameStarterInterface):
 
         if "WINEDLLOVERRIDES" not in env:
             env["WINEDLLOVERRIDES"] = ""
-        if not Args.enable_d3d11:
-            env["WINEDLLOVERRIDES"] += ";d3d11=;dxgi="
 
         wine_args = StarterWine.setup_wine_args(wine_args)
 
-        for opt in Args.game_options.split(" "):
+        for opt in "-rdevice {} {}".format(
+                Args.rendering_backend, Args.game_options).split(" "):
             if opt != "":
                 wine_args.append(opt)
 

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -552,7 +552,16 @@ def log_info_formatted_envars_and_args(runner, env_print, env, args):
     for name in env_print:
         name_value_pairs.append("{}={}".format(name, env[name]))
     env_str += "\n  ".join(name_value_pairs) + "\n  "
-    cmd_str += "\n    ".join(args)
+    # don't add newline after the first "-rdevice"
+    args_print = args.copy()
+    for i, arg in enumerate(args_print):
+        if arg == "-rdevice":
+            try:
+                args_print[i:i + 2] = ("{} {}".format(arg, args_print[i + 1]), )
+            except IndexError:
+                pass
+            break
+    cmd_str += "\n    ".join(args_print)
     logging.info("Running %s:\n  %s%s", runner, env_str, cmd_str)
 
 


### PR DESCRIPTION
Part of #208

It seems that [SCS Software is working on supporting D3D12 or (and?) Vulkan](https://forum.scssoft.com/viewtopic.php?f=41&t=301222).

Currently we can only choose whether to use D3D11 (or OpenGL) and we should be able to specify rendering backend name.

## New option/setting

Option: `--rendering-backend {auto,dx11,gl}` (`-r {auto,dx11,gl}`)
Game specific setting (`[ets2mp]`, `[ets2]`, `[atsmp]`, `[ats]`, or `[DEFAULT]` section): `rendering-backend = {dx11,gl}`

## Deprecation

`--enable-d3d11` (`-d`) option