### PR TITLE
configfile.py: Allow to specify whether to disable Steam Runtime

### DIFF
--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -98,6 +98,29 @@ class ConfigFile:
                 ConfigFile.format_error("without-rich-presence", ex)) from ex
 
     @staticmethod
+    def determine_disable_steamruntime(parser):
+        """
+        Determine whether to disable Steam Runtime.
+
+        parser: A ConfigParser object
+        """
+        config_src = ConfigSource.OPTION
+
+        if not Args.without_steam_runtime:
+            config_name = "without-steamruntime"
+            config_src = ConfigSource.FILE if config_name in parser[Args.game] \
+                else ConfigSource.DEFAULT
+            try:
+                if parser[Args.game].getboolean(config_name, fallback=False):
+                    Args.without_steam_runtime = True
+            except ValueError as ex:
+                raise ValueError(
+                    ConfigFile.format_error(config_name, ex)) from ex
+        logging.info(
+            "Whether to disable Steam Runtime: %s (%s)",
+            Args.without_steam_runtime, config_src.value)
+
+    @staticmethod
     def determine_rendering_backend(parser):
         """
         Determine rendering backend.
@@ -153,6 +176,9 @@ class ConfigFile:
         """
         # Discord Rich Presence
         ConfigFile.configure_rich_presence(parser, wants_rich_presence_cnt)
+
+        # whether to disable Steam Runtime
+        ConfigFile.determine_disable_steamruntime(parser)
 
         # rendering backend
         ConfigFile.determine_rendering_backend(parser)


### PR DESCRIPTION
Part of #208

It seems that some users need to disable Steam Runtime for some reasons: See #202

## New Setting

Game specific setting (`[ets2mp]`, `[ets2]`, `[atsmp]`, `[ats]`, or `[DEFAULT]` section): `without-steamruntime = [boolean]`