### PR TITLE
args.py, configfile.py: Allow to specify game options in configuration file

### DIFF
--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -285,7 +285,6 @@ SteamCMD can use your saved credentials for convenience.
         action="store_true"))
     store_actions.append(parser.add_argument(
         "--game-options", metavar="OPTIONS",
-        default="-nointro -64bit",
         help="""specify ATS/ETS2 options
                 Note: If specifying one option, use "--game-options=-option" format
                 [Default: "-nointro -64bit"]"""))

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -70,6 +70,29 @@ class ConfigFile:
             ConfigFile.handle_game_specific_settings(parser, wants_rich_presence_cnt)
 
     @staticmethod
+    def configure_game_options(parser):
+        """
+        Determine custom game options.
+
+        If no options are specified, "-nointro -64bit" will be used.
+        Note that game starters will prepend "-rdevice" to the given options.
+
+        parser: A ConfigParser object
+        """
+        config_src = ConfigSource.OPTION
+
+        if Args.game_options is None:
+            config_name = "game-options"
+            if config_name in parser[Args.game]:
+                config_src = ConfigSource.FILE
+                Args.game_options = parser[Args.game][config_name]
+            else:
+                config_src = ConfigSource.DEFAULT
+                Args.game_options = "-nointro -64bit"
+        logging.info(
+            "Game options: %s (%s)", Args.game_options, config_src.value)
+
+    @staticmethod
     def configure_rich_presence(parser, wants_rich_presence_cnt):
         """
         Determine whether to use wine-discord-ipc-bridge.
@@ -174,6 +197,9 @@ class ConfigFile:
         wants_rich_presence_cnt: The number of third-party program sections
                                  that have "wants-rich-presence = [true]"
         """
+        # game options
+        ConfigFile.configure_game_options(parser)
+
         # Discord Rich Presence
         ConfigFile.configure_rich_presence(parser, wants_rich_presence_cnt)
 


### PR DESCRIPTION
Part of #208
See also #163

## New Setting

Game specific setting (`[ets2mp]`, `[ets2]`, `[atsmp]`, `[ats]`, or `[DEFAULT]` section): `game-options = [options]`