### PR TITLE
download_files(): Fix TypeError when HTTP redirected

### DIFF
--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -198,7 +198,7 @@ def download_files(host, files_to_download, progress_count=None):
                     newpath += "?" + newloc.query
                 if not download_files(
                         newloc.netloc,
-                        [(newpath, dest, md5), ],
+                        [(newpath, dest["abspath"], md5), ],
                         (file_count, num_of_files)):
                     return False
                 # downloaded successfully from redirected URL


### PR DESCRIPTION
Fix #238

We should have replaced this `dest` with `dest["abspath"]` (for the absolute path to the destination file) in #226.