### PR TITLE
Allow to limit download speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Short option|Long option|Description
 (Not available)|`--activate-native-d3dcompiler-47`|Activate native 64-bit `d3dcompiler_47.dll` when starting (Needed for D3D11 renderer)
 (Not available)|`--check-windows-steam`|Check for the Windows Steam version on updating when using Proton
 (Not available)|`--disable-proton-overlay`|Disable Steam Overlay when using Proton
+(Not available)|`--download-throttle SPEED`|Limit download speed to SPEED (KiB/s), disabled if negative value is specified [Default: `-1`]
 (Not available)|`--game-options OPTIONS`|Specify ATS/ETS2 options Note: If specifying one option, use `--game-options=-option` format [Default: `-nointro -64bit`]
 (Not available)|`--native-steam-dir`|Choose native Steam installation, useful only if your Steam directory is not detected automatically [Default: `auto`]
 (Not available)|`--self-update`|Update files to the latest release and quit

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -180,6 +180,11 @@ SteamCMD can use your saved credentials for convenience.
         help="""use alternative configuration file
                 [Default: $XDG_CONFIG_HOME/truckersmp-cli/truckersmp-cli.conf]"""))
     store_actions.append(parser.add_argument(
+        "--download-throttle", metavar="SPEED", type=int,
+        default=-1,
+        help="""limit download speed to SPEED (KiB/s),
+                disabled if negative value is specified [Default: -1]"""))
+    store_actions.append(parser.add_argument(
         "-d", "--enable-d3d11",
         help="**DEPRECATED** use Direct3D 11 instead of OpenGL",
         action="store_true"))

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -48,6 +48,8 @@ class SteamCMD:
         if self._wine is not None:
             cmdline.append(self._wine)
         cmdline.append(self._path)
+        if Args.download_throttle > 0:
+            cmdline += ["+set_download_throttle", str(Args.download_throttle)]
         cmdline += args
         env_str = ""
         if self._env is not None:

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -787,9 +787,16 @@ def write_downloaded_file(outfile, res, md5hash, name_getting):
     with open(outfile, "wb") as f_out:
         downloaded = 0
         while True:
+            if Args.download_throttle > 0:
+                time_before_download = time.time()
             buf = res.read(bufsize)
             if not buf:
                 break
+            if Args.download_throttle > 0:
+                # wait if the speed is too fast
+                while (time.time() - time_before_download < bufsize / (
+                        1024 * Args.download_throttle)):
+                    time.sleep(0.001)
             downloaded += len(buf)
             f_out.write(buf)
             md5hash.update(buf)


### PR DESCRIPTION
Closes #231

This PR adds `--download-throttle=SPEED` option (KiB/s).

When the option is given, it limits download speed:

* `SteamCMD.run()`: Add `set_download_throttle` command to SteamCMD (See https://github.com/truckersmp-cli/truckersmp-cli/issues/231#issuecomment-907712126)
* `write_downloaded_file()`: Wait if the speed is too fast (For TruckersMP MOD files, wine-discord-ipc-bridge, and `d3dcompiler_47.dll`)