### PR TITLE
GitHub Actions: Allow to run automatic release jobs on every branch

### DIFF
--- a/.github/workflows/auto_release.yaml
+++ b/.github/workflows/auto_release.yaml
@@ -53,9 +53,7 @@ jobs:
         id: generate_changelog
         run: |
              import subprocess as subproc
-             args = ("git", "tag", "-l",
-               "--merged", "${{ steps.set_release_tag.outputs.tag }}",
-               "--sort=-v:refname")
+             args = ("git", "tag", "-l", "--sort=-v:refname", "--merged")
              basetag = subproc.check_output(args).decode("utf-8").splitlines()[1]
              args = (
                "git", "log",

--- a/.github/workflows/auto_release.yaml
+++ b/.github/workflows/auto_release.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: true
+          branch: ${{ github.ref }}
       - name: Install gcc-mingw-w64-x86-64
         run: |
              sudo apt -q update

--- a/.github/workflows/auto_release.yaml
+++ b/.github/workflows/auto_release.yaml
@@ -53,7 +53,9 @@ jobs:
         id: generate_changelog
         run: |
              import subprocess as subproc
-             args = ("git", "tag", "-l", "--sort=-v:refname")
+             args = ("git", "tag", "-l",
+               "--merged", "${{ steps.set_release_tag.outputs.tag }}",
+               "--sort=-v:refname")
              basetag = subproc.check_output(args).decode("utf-8").splitlines()[1]
              args = (
                "git", "log",

--- a/.github/workflows/auto_release.yaml
+++ b/.github/workflows/auto_release.yaml
@@ -2,8 +2,6 @@ name: Automatic release
 
 on:
   push:
-    branches:
-      - main
     paths:
       - RELEASE
 


### PR DESCRIPTION
This allows developers to release stable versions from stable branches.