### PR TITLE
GitHub Actions: Allow to run automatic release jobs only on main or stable branches

### DIFF
--- a/.github/workflows/auto_release.yaml
+++ b/.github/workflows/auto_release.yaml
@@ -2,6 +2,9 @@ name: Automatic release
 
 on:
   push:
+    branches:
+      - main
+      - stable_*
     paths:
       - RELEASE
 


### PR DESCRIPTION
Without this change, GitHub Actions releases a new version even when changing `RELEASE` file for "Release [version]" PRs.