### PR TITLE
args.py, configfile.py: Allow to specify "{game,prefix}-directory" settings

### DIFF
--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -55,10 +55,6 @@ def check_args_errors():
 
     game = "ats" if Args.ats else "ets2"
     Args.steamid = str(AppId.game[game])
-    if not Args.prefixdir:
-        Args.prefixdir = Dir.default_prefixdir[game]
-    if not Args.gamedir:
-        Args.gamedir = Dir.default_gamedir[game]
 
     # make sure proton and wine aren't chosen at the same time
     if Args.proton and Args.wine:
@@ -126,8 +122,6 @@ making sure it's the same directory as Proton""")
 
     # info
     logging.info("AppID/GameID: %s (%s)", Args.steamid, game)
-    logging.info("Game directory: %s", Args.gamedir)
-    logging.info("Prefix: %s", Args.prefixdir)
     if Args.proton:
         logging.info("Proton directory: %s", Args.protondir)
         logging.info("Steam Runtime directory: %s", Args.steamruntimedir)

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -70,6 +70,46 @@ class ConfigFile:
             ConfigFile.handle_game_specific_settings(parser, wants_rich_presence_cnt)
 
     @staticmethod
+    def configure_game_and_prefix_directories(parser):
+        """
+        Determine game and prefix directories.
+
+        parser: A ConfigParser object
+        """
+        config_src = dict(game=ConfigSource.OPTION, prefix=ConfigSource.OPTION)
+
+        game = Args.game.replace("mp", "")  # {ats,ets2} for default_{game,prefix}dir
+
+        if Args.gamedir is None:
+            config_name = "game-directory"
+            if config_name in parser[Args.game]:
+                config_src["game"] = ConfigSource.FILE
+                path = parser[Args.game][config_name]
+                if not os.path.isabs(path):
+                    # assume it's relative to our data directory
+                    path = os.path.join(Dir.truckersmp_cli_data, path)
+                Args.gamedir = path
+            else:
+                config_src["game"] = ConfigSource.DEFAULT
+                Args.gamedir = Dir.default_gamedir[game]
+        logging.info(
+            "Game directory: %s (%s)", Args.gamedir, config_src["game"].value)
+
+        if Args.prefixdir is None:
+            config_name = "prefix-directory"
+            if config_name in parser[Args.game]:
+                config_src["prefix"] = ConfigSource.FILE
+                path = parser[Args.game][config_name]
+                if not os.path.isabs(path):
+                    path = os.path.join(Dir.truckersmp_cli_data, path)
+                Args.prefixdir = path
+            else:
+                config_src["prefix"] = ConfigSource.DEFAULT
+                Args.prefixdir = Dir.default_prefixdir[game]
+        logging.info(
+            "Prefix directory: %s (%s)", Args.prefixdir, config_src["prefix"].value)
+
+    @staticmethod
     def configure_game_options(parser):
         """
         Determine custom game options.
@@ -217,6 +257,9 @@ class ConfigFile:
         wants_rich_presence_cnt: The number of third-party program sections
                                  that have "wants-rich-presence = [true]"
         """
+        # game/prefix directories
+        ConfigFile.configure_game_and_prefix_directories(parser)
+
         # game options
         ConfigFile.configure_game_options(parser)
 


### PR DESCRIPTION
Part of #208

## New Settings

Game specific setting (`[ets2mp]`, `[ets2]`, `[atsmp]`, `[ats]`, or `[DEFAULT]` section):

* `game-directory = [path]`
* `prefix-directory = [path]`