### PR TITLE
README.md, args.py: Update description for "--wine-desktop" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Short option|Long option|Description
 (Not available)|`--skip-update-proton`|Skip updating already-installed Proton when updating game with Proton enabled
 (Not available)|`--steamruntimedir`|Choose a different Steam Runtime directory for Proton 5.13 or newer
 (Not available)|`--use-wined3d`|Use OpenGL-based D3D11 instead of DXVK when using Proton
-(Not available)|`--wine-desktop SIZE`|Use Wine desktop, work around missing TruckerMP overlay after tabbing out using DXVK, mouse clicking won't work in other GUI apps while the game is running, SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)
+(Not available)|`--wine-desktop SIZE`|Use Wine desktop, work around resolution issue, mouse clicking won't work in other GUI apps while the game is running, SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)
 (Not available)|`--wine-steam-dir`|Choose a directory for Windows version of Steam [Default: `C:\Program Files (x86)\Steam` in the prefix]
 (Not available)|`--without-steam-runtime`|Don't use Steam Runtime even when using Proton 5.13 or newer
 (Not available)|`--without-wine-discord-ipc-bridge`|Don't use wine-discord-ipc-bridge for Discord Rich Presence

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -319,10 +319,9 @@ SteamCMD can use your saved credentials for convenience.
         action="store_true"))
     store_actions.append(parser.add_argument(
         "--wine-desktop", metavar="SIZE",
-        help="""use Wine desktop, work around missing TruckerMP overlay
-                after tabbing out using DXVK, mouse clicking won't work
-                in other GUI apps while the game is running, SIZE must be
-                'WIDTHxHEIGHT' format (e.g. 1920x1080)"""))
+        help="""use Wine desktop, work around resolution issue, mouse clicking
+                won't work in other GUI apps while the game is running,
+                SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)"""))
     store_actions.append(parser.add_argument(
         "--wine-steam-dir", metavar="DIR",
         help="""choose a directory for Windows version of Steam


### PR DESCRIPTION
Since #90 was fixed (upstream), this option is not necessary for this purpose. However, some users need the option to work around resolution issue (e.g. https://github.com/truckersmp-cli/truckersmp-cli/issues/257#issuecomment-978035584).