### PR TITLE
args.py, configfile.py: Allow to specify whether to disable Steam Overlay for Proton

### DIFF
--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -269,6 +269,7 @@ SteamCMD can use your saved credentials for convenience.
         action="store_true"))
     store_actions.append(parser.add_argument(
         "--disable-proton-overlay",
+        default=None,
         help="disable Steam Overlay when using Proton",
         action="store_true"))
     store_actions.append(parser.add_argument(

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -257,6 +257,12 @@ class ConfigFile:
             "without-steamruntime", False, "Whether to disable Steam Runtime",
         )
 
+        # whether to disable Steam Overlay
+        Args.disable_proton_overlay = ConfigFile.configure_game_specific_setting_boolean(
+            parser, Args.disable_proton_overlay,
+            "disable-proton-overlay", False, "Whether to disable Steam Overlay",
+        )
+
         # Proton/Steam Runtime directory
         if Args.proton:
             Args.protondir = ConfigFile.configure_game_specific_setting(


### PR DESCRIPTION
Part of #208

## New Settings

Game specific setting (`[ets2mp]`, `[ets2]`, `[atsmp]`, `[ats]`, or `[DEFAULT]` section):

* `disable-proton-overlay = [boolean]`