### PR TITLE
Rename --without-steam-runtime/without-steamruntime to --disable-steamruntime/disable-steamruntime

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Short option|Long option|Description
 (Not available)|`--activate-native-d3dcompiler-47`|Activate native 64-bit `d3dcompiler_47.dll` when starting (Needed for D3D11 renderer)
 (Not available)|`--check-windows-steam`|Check for the Windows Steam version on updating when using Proton
 (Not available)|`--disable-proton-overlay`|Disable Steam Overlay when using Proton
+(Not available)|`--disable-steamruntime`|Don't use Steam Runtime even when using Proton 5.13 or newer
 (Not available)|`--download-throttle SPEED`|Limit download speed to SPEED (KiB/s), disabled if negative value is specified [Default: `-1`]
 (Not available)|`--game-options OPTIONS`|Specify ATS/ETS2 options Note: If specifying one option, use `--game-options=-option` format [Default: `-nointro -64bit`]
 (Not available)|`--native-steam-dir`|Choose native Steam installation, useful only if your Steam directory is not detected automatically [Default: `auto`]
@@ -107,7 +108,6 @@ Short option|Long option|Description
 (Not available)|`--use-wined3d`|Use OpenGL-based D3D11 instead of DXVK when using Proton
 (Not available)|`--wine-desktop SIZE`|Use Wine desktop, work around resolution issue, mouse clicking won't work in other GUI apps while the game is running, SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)
 (Not available)|`--wine-steam-dir`|Choose a directory for Windows version of Steam [Default: `C:\Program Files (x86)\Steam` in the prefix]
-(Not available)|`--without-steam-runtime`|Don't use Steam Runtime even when using Proton 5.13 or newer
 (Not available)|`--without-wine-discord-ipc-bridge`|Don't use wine-discord-ipc-bridge for Discord Rich Presence
 (Not available)|`--version`|Print version information and quit
 

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -273,6 +273,11 @@ SteamCMD can use your saved credentials for convenience.
         help="disable Steam Overlay when using Proton",
         action="store_true"))
     store_actions.append(parser.add_argument(
+        "--disable-steamruntime",
+        default=None,
+        help="don't use Steam Runtime even when using Proton 5.13 or newer",
+        action="store_true"))
+    store_actions.append(parser.add_argument(
         "--downgrade",
         help="""**DEPRECATED** downgrade to the latest version supported by TruckersMP
                 Note: This option implies "--update" option and
@@ -320,7 +325,8 @@ SteamCMD can use your saved credentials for convenience.
     store_actions.append(parser.add_argument(
         "--without-steam-runtime",
         default=None,
-        help="don't use Steam Runtime even when using Proton 5.13 or newer",
+        help="""**DEPRECATED** don't use Steam Runtime even when using
+                Proton 5.13 or newer""",
         action="store_true"))
     store_actions.append(parser.add_argument(
         "--without-wine-discord-ipc-bridge",

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -254,8 +254,19 @@ class ConfigFile:
         # whether to disable Steam Runtime
         Args.without_steam_runtime = ConfigFile.configure_game_specific_setting_boolean(
             parser, Args.without_steam_runtime, "without-steamruntime",
+            False, "Whether to disable Steam Runtime (deprecated)",
+        )
+        Args.disable_steamruntime = ConfigFile.configure_game_specific_setting_boolean(
+            parser, Args.disable_steamruntime, "disable-steamruntime",
             False, "Whether to disable Steam Runtime",
         )
+        if Args.without_steam_runtime:
+            logging.warning(
+                "'--without-steam-runtime' option and "
+                "'without-steamruntime' setting are deprecated, "
+                "use '--disable-steamruntime' option or "
+                "'disable-steamruntime' setting instead")
+            Args.disable_steamruntime = True
 
         # whether to disable Steam Overlay
         Args.disable_proton_overlay = ConfigFile.configure_game_specific_setting_boolean(

--- a/truckersmp_cli/gamestarter.py
+++ b/truckersmp_cli/gamestarter.py
@@ -50,7 +50,7 @@ class StarterProton(GameStarterInterface):
         major, minor = get_proton_version(Args.protondir)
         logging.info("Proton version is (major=%d, minor=%d)", major, minor)
         self._use_steam_runtime = (
-            not Args.without_steam_runtime
+            not Args.disable_steamruntime
             and (major >= 6 or (major == 5 and minor >= 13)))
         logging.info(
             # use Steam Runtime container for Proton 5.13+

--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -158,11 +158,11 @@ See {URL.project_doc_inst} for additional information.""")
             # when starting with Proton + Steam Runtime
             run = os.path.join(Args.steamruntimedir, "run")
             var = os.path.join(Args.steamruntimedir, "var")
-            if not Args.without_steam_runtime:
+            if not Args.disable_steamruntime:
                 if not os.access(run, os.R_OK | os.X_OK):
                     sys.exit(
                         f'Steam Runtime is not found in {Args.steamruntimedir}\n'
-                        'Update the game or start with "--without-steam-runtime" option\n'
+                        'Update the game or start with "--disable-steamruntime" option\n'
                         'to disable the Steam Runtime')
                 if (not os.access(Args.steamruntimedir, os.R_OK | os.W_OK | os.X_OK)
                         or (os.path.isdir(var)

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -87,7 +87,7 @@ class SteamCMD:
             if Args.skip_update_proton:
                 logging.info("Skipping updating Proton and Steam Runtime")
             else:
-                if not Args.without_steam_runtime:
+                if not Args.disable_steamruntime:
                     # download/update Steam Runtime and Proton
                     os.makedirs(Args.steamruntimedir, exist_ok=True)
                     # Proton and Steam Linux Runtime work only on Linux systems


### PR DESCRIPTION
We already have `*steamruntime*` options/settings but `--without-steam-runtime` contains `steam-runtime`, not `steamruntime`.