### PR TITLE
log_info_formatted_envars_and_args(): Print all game options in one line

### DIFF
--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -534,15 +534,17 @@ def log_info_formatted_envars_and_args(runner, env_print, env, args):
     for name in env_print:
         name_value_pairs.append(f"{name}={env[name]}")
     env_str += "\n  ".join(name_value_pairs) + "\n  "
-    # don't add newline after the first "-rdevice"
-    args_print = args.copy()
-    for i, arg in enumerate(args_print):
-        if arg == "-rdevice":
-            try:
-                args_print[i:i + 2] = (f"{arg} {args_print[i + 1]}", )
-            except IndexError:
-                pass
+    args_print = []
+    opts_print = []
+    # print game options in one line
+    for i, arg in enumerate(args):
+        # game starter already put "-rdevice" first
+        if arg.startswith("-rdevice"):
+            opts_print += args[i:]
             break
+        args_print.append(arg)
+    if len(opts_print) > 0:
+        args_print.append("  " + " ".join(opts_print))
     cmd_str += "\n    ".join(args_print)
     logging.info("Running %s:\n  %s%s", runner, env_str, cmd_str)
 


### PR DESCRIPTION
Proton/multiplayer verbose output example:
```
** INFO **  Running Steam Runtime helper:
  SteamAppId=227300
  SteamGameId=227300
  PROTON_USE_WINED3D=0
  STEAM_COMPAT_CLIENT_INSTALL_PATH=/home/user/.steam
  STEAM_COMPAT_DATA_PATH=/home/user/.local/share/truckersmp-cli/Euro Truck Simulator 2/prefix
  python3
    /home/user/.local/share/truckersmp-cli/Proton/proton
    run
    /path/to/truckersmp-cli/truckersmp_cli/truckersmp-cli.exe
    /home/user/.local/share/truckersmp-cli/Euro Truck Simulator 2/data
    /home/user/.local/share/truckersmp-cli/TruckersMP
      -rdevice dx11 -nointro -64bit
```
Wine/singleplayer verbose output example:
```
** INFO **  Running Wine:
  WINEARCH=win64
  WINEDEBUG=-all
  WINEDLLOVERRIDES=
  WINEPREFIX=/home/user/.wine-truckersmp
  wine
    /home/user/.local/share/truckersmp-cli/Euro Truck Simulator 2/data/bin/win_x64/eurotrucks2.exe
      -rdevice dx11 -nointro -64bit
```