### PR TITLE
README.md, args.py: Remove already dropped fallback MOD directory from help

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Short option|Long option|Description
 `-g DIR`|`--gamedir DIR`|Choose a different directory for the game files [Default: `$XDG_DATA_HOME/truckersmp-cli/(Game name)/data`]
 `-i APPID`|`--proton-appid APPID`|Choose a different AppID for Proton (Needs an update for changes)
 `-l LOG`|`--logfile LOG`|Write log into LOG, `-vv` option is recommended [Default: Empty string (only stderr)] Note: Messages from Steam/SteamCMD won't be written, only from this script (Game logs are written into `My Documents/{ETS2,ATS}MP/logs/client_*.log`)
-`-m DIR`|`--moddir DIR`|Choose a different directory for the mod files [Default: `$XDG_DATA_HOME/truckersmp-cli/TruckersMP`, Fallback: `./truckersmp`]
+`-m DIR`|`--moddir DIR`|Choose a different directory for the mod files [Default: `$XDG_DATA_HOME/truckersmp-cli/TruckersMP`]
 `-n NAME`|`--account NAME`|Steam account name to use
 `-o DIR`|`--protondir DIR`|Choose a different Proton directory [Default: `$XDG_DATA_HOME/truckersmp-cli/Proton`]
 `-p`|`--proton`|Start the game with Proton [Default on Linux if neither Proton or Wine are specified]

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -205,8 +205,7 @@ SteamCMD can use your saved credentials for convenience.
     store_actions.append(parser.add_argument(
         "-m", "--moddir", metavar="DIR",
         help="""choose a different directory for the mod files
-                [Default: $XDG_DATA_HOME/truckersmp-cli/TruckersMP,
-                Fallback: ./truckersmp]"""))
+                [Default: $XDG_DATA_HOME/truckersmp-cli/TruckersMP]"""))
     store_actions.append(parser.add_argument(
         "-n", "--account", metavar="NAME",
         help="""steam account name to use


### PR DESCRIPTION
Already dropped in PR #237 (We should have removed in the PR).