### PR TITLE
StarterProton: Always wait for helper process to terminate

### DIFF
--- a/truckersmp_cli/gamestarter.py
+++ b/truckersmp_cli/gamestarter.py
@@ -266,6 +266,7 @@ class StarterProton(GameStarterInterface):
                     env=env, stdout=subproc.PIPE, stderr=subproc.STDOUT) as proc:
                 if Args.verbose:
                     print_child_output(proc)
+                proc.wait()
         except subproc.CalledProcessError as ex:
             logging.error(
                 "Steam Runtime helper exited abnormally:\n%s", ex.output.decode("utf-8"))


### PR DESCRIPTION
As of 0.8.1, `StarterProton` does not start game when not specifying `-v` or `-vv`.

This PR fixes the issue.