### PR TITLE
Allow to use Flatpak version of Steam

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Short option|Long option|Description
 `-b VERSION`|`--beta VERSION`|Set game version to VERSION, useful for downgrading (e.g. `temporary_1_35`)
 `-c FILE`|`--configfile FILE`|Use alternative configuration file<br><br>Default: `$XDG_CONFIG_HOME/truckersmp-cli/truckersmp-cli.conf`
 `-d`|`--enable-d3d11`|**DEPRECATED** Use Direct3D 11 instead of OpenGL
+`-f`|`--flatpak-steam`|Use Flatpak version of Steam with Proton<br><br>Note: Currently Steam Runtime is not supported and will be disabled
 `-g DIR`|`--gamedir DIR`|Choose a different directory for the game files<br><br>Default: `$XDG_DATA_HOME/truckersmp-cli/(Game name)/data`
 `-i APPID`|`--proton-appid APPID`|Choose a different AppID for Proton (Needs an update for changes)
 `-l LOG`|`--logfile LOG`|Write log into LOG, `-vv` option is recommended<br><br>Default: Empty string (only stderr)<br>Note: Messages from Steam/SteamCMD won't be written, only from this script<br>See [#default-directories](https://github.com/truckersmp-cli/truckersmp-cli#default-directories) for game log locations.

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -186,6 +186,12 @@ SteamCMD can use your saved credentials for convenience.
                 [Default if neither ATS or ETS2 are specified] """,
         action="store_true"))
     store_actions.append(parser.add_argument(
+        "-f", "--flatpak-steam",
+        default=None,
+        help="""use Flatpak version of Steam with Proton
+                Note: Currently Steam Runtime is not supported and will be disabled""",
+        action="store_true"))
+    store_actions.append(parser.add_argument(
         "-g", "--gamedir", metavar="DIR",
         help="""choose a different directory for the game files
                 [Default: $XDG_DATA_HOME/truckersmp-cli/(Game name)/data]"""))

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -253,6 +253,16 @@ class ConfigFile:
                 "'disable-steamruntime' setting instead")
             Args.disable_steamruntime = True
 
+        # whether to use Flatpak version of Steam
+        Args.flatpak_steam = self._configure_game_specific_setting_boolean(
+            Args.flatpak_steam, "flatpak-steam",
+            False, "Whether to use Flatpak version of Steam",
+        )
+        # disable Steam Runtime when using Flatpak version of Steam
+        if Args.flatpak_steam:
+            logging.info("Disabling Steam Runtime for Flatpak")
+            Args.disable_steamruntime = True
+
         # whether to disable Steam Overlay
         Args.disable_proton_overlay = self._configure_game_specific_setting_boolean(
             Args.disable_proton_overlay, "disable-proton-overlay",

--- a/truckersmp_cli/flatpak_helper.py
+++ b/truckersmp_cli/flatpak_helper.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+"""
+Helper script for Flatpak.
+
+This script starts Flatpak version of Steam and steamruntime_helper.py.
+"""
+
+import os
+import subprocess as subproc
+import sys
+import time
+from gettext import ngettext
+
+
+def wait_for_flatpak_steam(timeout=99):
+    """Wait for Flatpak version of Steam to be running."""
+    loginvdf = os.path.expanduser("~/.local/share/Steam/config/loginusers.vdf")
+    try:
+        stat = os.stat(loginvdf)
+        loginvdf_timestamp = stat.st_mtime
+    except OSError:
+        loginvdf_timestamp = 0
+
+    waittime = timeout
+    while waittime > 0:
+        # "\r" can't be used here because this helper is subprocess
+        print(ngettext(
+            "Waiting {} second for steam to start up.",
+            "Waiting {} seconds for steam to start up.",
+            waittime).format(waittime), flush=True)
+        time.sleep(1)
+        waittime -= 1
+        try:
+            stat = os.stat(loginvdf)
+            if stat.st_mtime > loginvdf_timestamp:
+                break
+        except OSError:
+            pass
+
+
+def main():
+    """Start Flatpak version of Steam and steamruntime_helper.py."""
+    # pylint: disable=consider-using-with
+
+    args = sys.argv[1:]
+    verbose = "-v" in args or "-vv" in args
+
+    subproc.Popen(("steam", ), stdout=subproc.DEVNULL, stderr=subproc.STDOUT)
+    wait_for_flatpak_steam()
+
+    try:
+        with subproc.Popen(
+                args,
+                stdout=subproc.PIPE if verbose else subproc.DEVNULL,
+                stderr=subproc.STDOUT) as proc:
+            if verbose:
+                print("Helper output:", flush=True)
+            if proc.stdout is not None:
+                for line in proc.stdout:
+                    try:
+                        print(line.decode("utf-8"), end="", flush=True)
+                    except UnicodeDecodeError:
+                        print(
+                            "!! NON UNICODE OUTPUT !!", repr(line),
+                            sep="  ", end="", flush=True)
+            proc.wait()
+    except subproc.CalledProcessError as ex:
+        print("Helper output:\n" + ex.output.decode("utf-8"), file=sys.stderr, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -227,9 +227,15 @@ def update_game():
     SteamCMD.download_steamcmd(steamcmd_path, steamcmd_url)
 
     # Linux version of Steam
-    if platform.system() == "Linux" and check_steam_process(use_proton=True):
-        logging.debug("Closing Linux version of Steam")
-        subproc.call(("steam", "-shutdown"))
+    if platform.system() == "Linux":
+        try:
+            logging.debug("Trying to close Flatpak version of Steam")
+            subproc.check_call(("flatpak", "kill", "com.valvesoftware.Steam"))
+        except (OSError, subproc.CalledProcessError):
+            pass
+        if check_steam_process(use_proton=True):
+            logging.debug("Closing Linux version of Steam")
+            subproc.call(("steam", "-shutdown"))
     # Windows version of Steam
     if (Args.check_windows_steam
             and wine

--- a/truckersmp_cli/variables.py
+++ b/truckersmp_cli/variables.py
@@ -38,6 +38,7 @@ class Dir:
         ats=os.path.join(truckersmp_cli_data, "American Truck Simulator/prefix"),
         ets2=os.path.join(truckersmp_cli_data, "Euro Truck Simulator 2/prefix"),
     )
+    flatpak_steamdir = os.path.expanduser("~/.local/share/Steam")
     default_moddir = os.path.join(truckersmp_cli_data, "TruckersMP")
     default_protondir = os.path.join(truckersmp_cli_data, "Proton")
     default_steamruntimedir = os.path.join(truckersmp_cli_data, "SteamRuntime")
@@ -76,6 +77,7 @@ class File:
     ipcbridge = os.path.join(Dir.ipcbrdir, "winediscordipcbridge.exe")
     ipcbridge_md5 = "78fef85810c5bb8e492d3f67f48947a5"
     sdl2_soname = "libSDL2-2.0.so.0"
+    flatpak_helper = os.path.join(Dir.scriptdir, "flatpak_helper.py")
     steamruntime_helper = os.path.join(Dir.scriptdir, "steamruntime_helper.py")
 
 


### PR DESCRIPTION
Closes #52

This PR allows to start games using Flatpak version of Steam.

## Limitations

* Steam Runtime can't be used in Flatpak container
    * Steam Runtime wants `dbus-launch` but the Flatpak container doesn't provide it (as of Jan 2022)
    * IMO, if ETS2 and ATS (including TruckersMP) work in the Flatpak container, Steam Runtime container is unnecessary: Currently no need to use Steam Runtime
* Even when Flatpak version of Steam is already running, `truckersmp-cli` needs to launch it via our new helper script `flatpak_helper.py` in order to be able to start games
* If Flatpak version of Steam is already running, truckersmp-cli kills it before starting Steam

## How to enable

### Option

`-f`/`--flatpak-steam`

### Configuration file

`flatpak-steam = [boolean (true)]`

Example:
```ini
[DEFAULT]
flatpak-steam = yes
```