### PR TITLE
update_game(): Suppress error when failing to close Flatpak version of Steam

### DIFF
--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -230,7 +230,8 @@ def update_game():
     if platform.system() == "Linux":
         try:
             logging.debug("Trying to close Flatpak version of Steam")
-            subproc.check_call(("flatpak", "kill", "com.valvesoftware.Steam"))
+            subproc.check_call(
+                ("flatpak", "kill", "com.valvesoftware.Steam"), stderr=subproc.DEVNULL)
         except (OSError, subproc.CalledProcessError):
             pass
         if check_steam_process(use_proton=True):


### PR DESCRIPTION
`truckersmp-cli` doesn't need to show this message even when failing, because it only makes sure that Steam is not running.

We *can check* whether Flatpak version of Steam is already running by `flatpak ps`, but `truckersmp-cli` needs to execute 2 commands (`flatpak ps` and `flatpak kill`) when running.