### PR TITLE
Allow to specify Proton version ("X.Y" format) instead of AppId

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Short option|Long option|Description
 `-d`|`--enable-d3d11`|**DEPRECATED** Use Direct3D 11 instead of OpenGL
 `-f`|`--flatpak-steam`|Use Flatpak version of Steam with Proton<br><br>Note: Currently Steam Runtime is not supported and will be disabled
 `-g DIR`|`--gamedir DIR`|Choose a different directory for the game files<br><br>Default: `$XDG_DATA_HOME/truckersmp-cli/(Game name)/data`
-`-i APPID`|`--proton-appid APPID`|Choose a different AppID for Proton (Needs an update for changes)
+`-i APPID`|`--proton-appid APPID`|Choose a different AppID or version name ("X.Y" format) of Proton (Needs an update for changes)
 `-l LOG`|`--logfile LOG`|Write log into LOG, `-vv` option is recommended<br><br>Default: Empty string (only stderr)<br>Note: Messages from Steam/SteamCMD won't be written, only from this script<br>See [#default-directories](https://github.com/truckersmp-cli/truckersmp-cli#default-directories) for game log locations.
 `-m DIR`|`--moddir DIR`|Choose a different directory for the mod files<br><br>Default: `$XDG_DATA_HOME/truckersmp-cli/TruckersMP`
 `-n NAME`|`--account NAME`|Steam account name to use

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -107,6 +107,17 @@ def check_args_errors_early():
             logging.info("Platform is not Linux, using Wine")
             Args.wine = True
 
+    # check Proton AppId
+    try:
+        int(Args.proton_appid)  # no error if raw AppId is given
+    except ValueError:
+        # find Proton AppId of the given version
+        if "." not in Args.proton_appid:
+            sys.exit(f'Invalid AppId "{Args.proton_appid}"')
+        if Args.proton_appid not in AppId.proton:
+            sys.exit(f'The AppId of Proton "{Args.proton_appid}" is unknown.')
+        Args.proton_appid = AppId.proton[Args.proton_appid]
+
 
 def create_arg_parser():
     """
@@ -170,9 +181,10 @@ SteamCMD can use your saved credentials for convenience.
         help="""choose a different directory for the game files
                 [Default: $XDG_DATA_HOME/truckersmp-cli/(Game name)/data]"""))
     store_actions.append(parser.add_argument(
-        "-i", "--proton-appid", metavar="APPID", type=int,
-        default=AppId.proton[AppId.proton["default"]],
-        help=f"""choose a different AppID for Proton (Needs an update for changes)
+        "-i", "--proton-appid", metavar="APPID",
+        default=str(AppId.proton[AppId.proton["default"]]),
+        help=f"""choose a different AppID or version name ("X.Y" format) of Proton
+                 (Needs an update for changes)
                  [Default: {AppId.proton[AppId.proton["default"]]}]"""))
     store_actions.append(parser.add_argument(
         "-l", "--logfile", metavar="LOG",

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -107,7 +107,7 @@ class SteamCMD:
                     [
                         "+force_install_dir", Args.protondir,
                         "+login", "anonymous",
-                        "+app_update", str(Args.proton_appid), "validate",
+                        "+app_update", Args.proton_appid, "validate",
                         "+quit",
                     ]
                 )


### PR DESCRIPTION
* `-i 6.3` = `-i 1580130`
* `-i 5.13` = `-i 1420170`
* `-i 5.0` = `-i 1245040`
* `-i 4.11` = `-i 1113280`