### PR TITLE
args.py: Store Args.proton_appid as string when Proton version string is given

### DIFF
--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -116,7 +116,7 @@ def check_args_errors_early():
             sys.exit(f'Invalid AppId "{Args.proton_appid}"')
         if Args.proton_appid not in AppId.proton:
             sys.exit(f'The AppId of Proton "{Args.proton_appid}" is unknown.')
-        Args.proton_appid = AppId.proton[Args.proton_appid]
+        Args.proton_appid = str(AppId.proton[Args.proton_appid])
 
 
 def create_arg_parser():


### PR DESCRIPTION
This fixes `AttributeError: 'int' object has no attribute 'startswith'` error when installing Proton with `X.Y` version string.