### PR TITLE
Setup.cfg: Set python_requires to >=3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 platforms = x86_64 POSIX systems
 
 [options]
-python_requires = >=3.3
+python_requires = >=3.6
 packages = truckersmp_cli
 scripts = truckersmp-cli
 zip_safe = False


### PR DESCRIPTION
We changed the version requirement in PR #240 (Milestone:0.8.0).