### PR TITLE
Add an action for killing active processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Name|Description
 `downgrade`|Downgrade game (install game from `temporary_X_Y` branch)
 `updateandstart` (or `ustart`)|`update` + `start` (Default)
 `downgradeandstart` (or `dstart`)|`downgrade` + `start`
+`kill`|Kill running processes in the same Wine prefix
 
 ### Game names
 

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -22,6 +22,7 @@ ACTIONS = (
     ("ustart", 'same as "updateandstart" ("update" and "start")'),
     ("downgradeandstart", '"downgrade" and "start"'),
     ("dstart", 'same as "downgradeandstart" ("downgrade" and "start")'),
+    ("kill", "kill running processes in the same Wine prefix"),
 )
 
 GAMES = (
@@ -346,7 +347,7 @@ def process_actions_gamenames():
     This function must be called after parse_args(namespace=Args)
     """
     # actions
-    Args.start = Args.update = Args.downgrade = False
+    Args.start = Args.update = Args.downgrade = Args.kill_procs = False
     if Args.action == "start":
         Args.start = True
     elif Args.action == "update":
@@ -357,6 +358,8 @@ def process_actions_gamenames():
         Args.update = Args.start = True
     elif Args.action in ("downgradeandstart", "dstart"):
         Args.downgrade = Args.update = Args.start = True
+    elif Args.action == "kill":
+        Args.kill_procs = True
 
     # game names
     Args.ets2 = Args.ats = Args.singleplayer = False

--- a/truckersmp_cli/main.py
+++ b/truckersmp_cli/main.py
@@ -149,8 +149,7 @@ See {URL.project_doc_inst} for additional information.""")
         logging.debug("Updating mod files")
         update_mod()
 
-    # start truckersmp with proton or wine
-    if Args.start:
+    if Args.kill_procs or Args.start:
         if Args.proton:
             # check for Proton availability when starting with Proton
             if not os.access(os.path.join(Args.protondir, "proton"), os.R_OK):
@@ -176,7 +175,14 @@ See {URL.project_doc_inst} for additional information.""")
         if not check_libsdl2():
             sys.exit("SDL2 was not found on your system.")
         starter = StarterProton(cfg) if Args.proton else StarterWine(cfg)
-        logging.debug("Starting game with %s", starter.runner_name)
-        starter.run()
+        logging.debug("Created starter for %s", starter.runner_name)
+        # kill active processes if "kill" action is given
+        if Args.kill_procs:
+            logging.info("Killing running processes")
+            starter.kill_active_procs()
+        # start TruckersMP with Proton or Wine
+        if Args.start:
+            logging.info("Starting game")
+            starter.run()
 
     sys.exit()

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -321,6 +321,17 @@ def get_mtime(files):
     return results
 
 
+def get_proton_dist_dir():
+    """Determine and return the path to the dist directorty in Proton directory."""
+    return os.path.join(
+        Args.protondir,
+        # the subdir is "dist" (official) or "files" (some forked builds)
+        "files" if os.access(
+            os.path.join(Args.protondir, "files/bin/wine"),
+            os.R_OK | os.X_OK,
+        ) else "dist")
+
+
 def get_proton_version(protondir):
     """
     Get Proton version from "version" file.


### PR DESCRIPTION
The new action (`kill`) allows users to run `wineserver -k` from our script.

* Proton: `(protondir)/{dist,files}/bin/wineserver` with/without Steam Runtime
* Wine: `$WINESERVER` or `wineserver`

This may work around for #216: I can reproduce the error if I start a process in the same prefix beforehand, and can't reproduce after running the action.