### PR TITLE
Avoid using the "**" pattern

### DIFF
--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -268,9 +268,25 @@ def find_discord_ipc_sockets():
     #   https://github.com/0e4ef622/wine-discord-ipc-bridge/pull/24
     # * $XDG_RUNTIME_DIR/snap.discord/discord-ipc-*
     #   https://github.com/0e4ef622/wine-discord-ipc-bridge/issues/17#issuecomment-982285675
-    return glob.glob(
-        os.path.join(os.getenv("XDG_RUNTIME_DIR", "/tmp"), "**", "discord-ipc-*"),
-        recursive=True)
+
+    # Combine globs to avoid the use of "**":
+    # Using the “**” pattern in large directory trees may consume a huge amount of time.
+    results = glob.glob(
+        os.path.join(
+            os.getenv("XDG_RUNTIME_DIR", "/tmp"),
+            "discord-ipc-*"))
+    results += glob.glob(
+        os.path.join(
+            os.getenv("XDG_RUNTIME_DIR", "/tmp"),
+            "app",
+            "com.discordapp.Discord",
+            "discord-ipc-*"))
+    results += glob.glob(
+        os.path.join(
+            os.getenv("XDG_RUNTIME_DIR", "/tmp"),
+            "snap.discord",
+            "discord-ipc-*"))
+    return results
 
 
 def get_current_steam_user():


### PR DESCRIPTION
This was introduced in https://github.com/truckersmp-cli/truckersmp-cli/pull/287 and seems to be a plausible cause of #345 

@Synthron Since you seem versatile in python, may I ask you to give this a try?

fix #345 