### PR TITLE
Fix Steam library folders changing on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Key-Value-Pair|Description
 `disable-proton-overlay = [boolean]`|Disable Steam Overlay when using Proton<br><br>Default: `no`
 `log-file = [path]`|Write log into the specified file, `-vv` option is recommended<br><br>Default: Empty string (only stderr)<br>Note: Messages from Steam/SteamCMD won't be written, only from this script (Game logs are written into `My Documents/{ETS2,ATS}MP/logs/client_*.log`)
 `truckersmp-directory = [path]`|Choose a different directory for the mod files<br><br>Default: `$XDG_DATA_HOME/truckersmp-cli/TruckersMP`
+`do-not-backup-libraryfolders-vdf = [boolean]`|Don't back up the Steam library folders file before logging in with SteamCMD<br>See [pull request #377][github:pr377] for details.
 
 ### Sections for third party programs
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Short option|Long option|Description
 (Not available)|`--wine-desktop SIZE`|Use Wine desktop, work around resolution issue, mouse clicking won't work in other GUI apps while the game is running, SIZE must be 'WIDTHxHEIGHT' format (e.g. 1920x1080)
 (Not available)|`--wine-steam-dir`|Choose a directory for Windows version of Steam<br><br>Default: `C:\Program Files (x86)\Steam` in the prefix
 (Not available)|`--without-wine-discord-ipc-bridge`|Don't use wine-discord-ipc-bridge for Discord Rich Presence
+(Not available)|`--do-not-backup-libraryfolders-vdf`|Don't back up the Steam library folders file before logging in with SteamCMD (see [pull request #377][github:pr377] for details)
 (Not available)|`--version`|Print version information and quit
 
 ## Build
@@ -401,6 +402,7 @@ and TheUnknownNO's unofficial [TruckersMP-Launcher][github:truckersmp-launcher].
 [github:issue147]: https://github.com/truckersmp-cli/truckersmp-cli/issues/147
 [github:issue248]: https://github.com/truckersmp-cli/truckersmp-cli/issues/248
 [github:issue253]: https://github.com/truckersmp-cli/truckersmp-cli/issues/253
+[github:pr377]: https://github.com/truckersmp-cli/truckersmp-cli/pull/377
 [github:kakurasan]: https://github.com/kakurasan
 [github:Lucki]: https://github.com/Lucki
 [github:proton]: https://github.com/ValveSoftware/Proton

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -302,6 +302,11 @@ SteamCMD can use your saved credentials for convenience.
         help="don't use wine-discord-ipc-bridge for Discord Rich Presence",
         action="store_true"))
     store_actions.append(parser.add_argument(
+        "--do-not-backup-libraryfolders-vdf",
+        default=None,
+        help="don't back up the Steam library folders file before logging in with SteamCMD",
+        action="store_true"))
+    store_actions.append(parser.add_argument(
         "--version",
         help="""print version information and quit""",
         action="store_true"))

--- a/truckersmp_cli/args.py
+++ b/truckersmp_cli/args.py
@@ -304,7 +304,8 @@ SteamCMD can use your saved credentials for convenience.
     store_actions.append(parser.add_argument(
         "--do-not-backup-libraryfolders-vdf",
         default=None,
-        help="don't back up the Steam library folders file before logging in with SteamCMD",
+        help="""don't back up the Steam library folders file before logging in with
+                SteamCMD""",
         action="store_true"))
     store_actions.append(parser.add_argument(
         "--version",

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -278,6 +278,12 @@ class ConfigFile:
         # Discord Rich Presence
         self._configure_rich_presence(wants_rich_presence_cnt)
 
+        # whether to not back up the Steam library folders file
+        Args.do_not_backup_libraryfolders_vdf = self._configure_game_specific_setting_boolean(
+            Args.do_not_backup_libraryfolders_vdf, "do-not-backup-libraryfolders-vdf",
+            False, "Whether to not back up the Steam library folders file before logging in with SteamCMD",
+        )
+
         # rendering backend
         self._determine_rendering_backend()
 

--- a/truckersmp_cli/configfile.py
+++ b/truckersmp_cli/configfile.py
@@ -279,9 +279,13 @@ class ConfigFile:
         self._configure_rich_presence(wants_rich_presence_cnt)
 
         # whether to not back up the Steam library folders file
-        Args.do_not_backup_libraryfolders_vdf = self._configure_game_specific_setting_boolean(
-            Args.do_not_backup_libraryfolders_vdf, "do-not-backup-libraryfolders-vdf",
-            False, "Whether to not back up the Steam library folders file before logging in with SteamCMD",
+        Args.do_not_backup_libraryfolders_vdf = (
+            self._configure_game_specific_setting_boolean(
+                Args.do_not_backup_libraryfolders_vdf, "do-not-backup-libraryfolders-vdf",
+                False,
+                "Whether to not back up the Steam library folders file before logging "
+                "in with SteamCMD",
+            )
         )
 
         # rendering backend

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -4,18 +4,18 @@ SteamCMD handler for truckersmp-cli main script.
 Licensed under MIT.
 """
 
+import codecs
 import io
 import logging
 import os
 import platform
+import pty
+import shutil
 import subprocess as subproc
 import sys
 import tarfile
 import urllib.request
 from zipfile import ZipFile
-import shutil
-import re
-import pty
 
 from .truckersmp import determine_game_branch
 from .utils import check_and_unpack_tar, check_steam_process, get_steamdir
@@ -36,7 +36,6 @@ class SteamCMD:
         self._path = path
         self._wine = wine
         self._env = env
-        self._login_re = re.compile(r"Waiting for client config.*")
 
     @staticmethod
     def download_steamcmd(dest, url):
@@ -136,10 +135,13 @@ class SteamCMD:
 
     def _create_lib_backup(self):
         """Create backup of steamlibvdf."""
-        lib = os.path.join(get_steamdir(), File.steamlibvdf_inner)
+        steamdir = get_steamdir()
+        if not steamdir:
+            return
+        lib = os.path.join(steamdir, File.steamlibvdf_inner)
         if not os.path.isfile(lib):
             return
-        
+
         bak = f"{lib}.truckersmp-cli.bak"
         try:
             shutil.copy2(lib, bak)
@@ -153,40 +155,52 @@ class SteamCMD:
         """Restore steamlibvdf and remove backup copy."""
         if not self._lib_backup:
             return
-        
+
         lib, bak = self._lib_backup
         try:
             shutil.copy2(bak, lib)
             logging.debug("Restored %s from %s", lib, bak)
         except OSError as ex:
             logging.warning("Failed to restore %s from %s: %s", lib, bak, ex)
-            
+
         try:
             os.remove(bak)
         except OSError:
             pass
-        
+
     def _try_restore_on_login(self, line):
         """Check for login pattern in line and restore backup if found."""
-        if not self._backup_restored and self._lib_backup and self._login_re.search(line):
+        if not self._backup_restored and self._search_pattern in line:
+            logging.debug("Found login pattern, restoring steamlibvdf")
             self._restore_lib_backup()
             self._backup_restored = True
-                
+
     def _run_interactive(self, cmdline):
         """Run SteamCMD interactively with PTY for immediate I/O."""
-        
+
+        self._decoder = codecs.getincrementaldecoder('utf-8')(errors='ignore')
+        self._search_buffer = ""
+        self._search_pattern = "Waiting for client config"
+        self._max_pattern_len = len(self._search_pattern)
+
         def master_read(fd):
             data = os.read(fd, 1024)
             if data:
-                text = data.decode('utf-8', errors='ignore')
-                self._try_restore_on_login(text)
+                self._search_buffer += self._decoder.decode(data)
+                self._try_restore_on_login(self._search_buffer)
+                if len(self._search_buffer) > self._max_pattern_len * 4:
+                    self._search_buffer = self._search_buffer[-self._max_pattern_len * 2:]
             return data
-        
+
         try:
             returncode = pty.spawn(cmdline, master_read=master_read)
             if returncode != 0:
+                if not self._backup_restored:
+                    self._restore_lib_backup()
                 sys.exit("SteamCMD exited abnormally")
         except OSError as ex:
+            if not self._backup_restored:
+                self._restore_lib_backup()
             sys.exit(f"Failed to start SteamCMD: {ex}")
 
     def run(self, args):

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -198,8 +198,8 @@ class SteamCMD:
         try:
             returncode = pty.spawn(cmdline, master_read=master_read)
             if returncode != 0:
-                if (not self._backup_restored and not
-                Args.do_not_backup_libraryfolders_vdf):
+                if (not self._backup_restored
+                        and not Args.do_not_backup_libraryfolders_vdf):
                     self._restore_lib_backup()
                 sys.exit("SteamCMD exited abnormally")
         except OSError as ex:

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -185,7 +185,7 @@ class SteamCMD:
 
         def master_read(fd):
             data = os.read(fd, 1024)
-            if data:
+            if data and not Args.do_not_backup_libraryfolders_vdf:
                 self._search_buffer += self._decoder.decode(data)
                 self._try_restore_on_login(self._search_buffer)
                 if len(self._search_buffer) > self._max_pattern_len * 4:
@@ -195,11 +195,11 @@ class SteamCMD:
         try:
             returncode = pty.spawn(cmdline, master_read=master_read)
             if returncode != 0:
-                if not self._backup_restored:
+                if not self._backup_restored and not Args.do_not_backup_libraryfolders_vdf:
                     self._restore_lib_backup()
                 sys.exit("SteamCMD exited abnormally")
         except OSError as ex:
-            if not self._backup_restored:
+            if not self._backup_restored and not Args.do_not_backup_libraryfolders_vdf:
                 self._restore_lib_backup()
             sys.exit(f"Failed to start SteamCMD: {ex}")
 
@@ -234,7 +234,7 @@ class SteamCMD:
             cmd_str += arg
 
         # create backup of Steam library folders
-        if Args.proton:
+        if Args.proton and not Args.do_not_backup_libraryfolders_vdf:
             self._create_lib_backup()
             self._backup_restored = False
 

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -19,11 +19,13 @@ from zipfile import ZipFile
 
 from .truckersmp import determine_game_branch
 from .utils import check_and_unpack_tar, check_steam_process, get_steamdir
-from .variables import AppId, Args, Dir, URL, File
+from .variables import AppId, Args, Dir, File, URL
 
 
 class SteamCMD:
     """SteamCMD command."""
+
+    _LOGIN_PATTERN = "Waiting for client config"
 
     def __init__(self, path, wine=None, env=None):
         """
@@ -33,6 +35,10 @@ class SteamCMD:
         wine: Path to "wine" command (can be None when native SteamCMD is used)
         env: "env" argument for subprocess.Popen
         """
+        self._lib_backup = None
+        self._backup_restored = False
+        self._decoder = codecs.getincrementaldecoder('utf-8')(errors='ignore')
+        self._search_buffer = ""
         self._path = path
         self._wine = wine
         self._env = env
@@ -170,32 +176,30 @@ class SteamCMD:
 
     def _try_restore_on_login(self, line):
         """Check for login pattern in line and restore backup if found."""
-        if not self._backup_restored and self._search_pattern in line:
+        if not self._backup_restored and self._LOGIN_PATTERN in line:
             logging.debug("Found login pattern, restoring steamlibvdf")
             self._restore_lib_backup()
             self._backup_restored = True
 
     def _run_interactive(self, cmdline):
         """Run SteamCMD interactively with PTY for immediate I/O."""
-
-        self._decoder = codecs.getincrementaldecoder('utf-8')(errors='ignore')
         self._search_buffer = ""
-        self._search_pattern = "Waiting for client config"
-        self._max_pattern_len = len(self._search_pattern)
+        max_pattern_len = len(self._LOGIN_PATTERN)
 
         def master_read(fd):
             data = os.read(fd, 1024)
             if data and not Args.do_not_backup_libraryfolders_vdf:
                 self._search_buffer += self._decoder.decode(data)
                 self._try_restore_on_login(self._search_buffer)
-                if len(self._search_buffer) > self._max_pattern_len * 4:
-                    self._search_buffer = self._search_buffer[-self._max_pattern_len * 2:]
+                if len(self._search_buffer) > max_pattern_len * 4:
+                    self._search_buffer = self._search_buffer[-max_pattern_len * 2:]
             return data
 
         try:
             returncode = pty.spawn(cmdline, master_read=master_read)
             if returncode != 0:
-                if not self._backup_restored and not Args.do_not_backup_libraryfolders_vdf:
+                if (not self._backup_restored and not
+                Args.do_not_backup_libraryfolders_vdf):
                     self._restore_lib_backup()
                 sys.exit("SteamCMD exited abnormally")
         except OSError as ex:

--- a/truckersmp_cli/steamcmd.py
+++ b/truckersmp_cli/steamcmd.py
@@ -37,7 +37,7 @@ class SteamCMD:
         """
         self._lib_backup = None
         self._backup_restored = False
-        self._decoder = codecs.getincrementaldecoder('utf-8')(errors='ignore')
+        self._decoder = codecs.getincrementaldecoder("utf-8")(errors="ignore")
         self._search_buffer = ""
         self._path = path
         self._wine = wine
@@ -151,7 +151,7 @@ class SteamCMD:
         bak = f"{lib}.truckersmp-cli.bak"
         try:
             shutil.copy2(lib, bak)
-            logging.debug("Backed up %s -> %s", lib, bak)
+            logging.info("Backed up %s -> %s", lib, bak)
             self._lib_backup = (lib, bak)
         except OSError as ex:
             logging.warning("Failed to back up %s: %s", lib, ex)
@@ -165,7 +165,7 @@ class SteamCMD:
         lib, bak = self._lib_backup
         try:
             shutil.copy2(bak, lib)
-            logging.debug("Restored %s from %s", lib, bak)
+            logging.info("Restored %s from %s", lib, bak)
         except OSError as ex:
             logging.warning("Failed to restore %s from %s: %s", lib, bak, ex)
 
@@ -173,16 +173,26 @@ class SteamCMD:
             os.remove(bak)
         except OSError:
             pass
+        else:
+            logging.info("Removed %s", bak)
 
     def _try_restore_on_login(self, line):
-        """Check for login pattern in line and restore backup if found."""
+        """
+        Check for login pattern in line and restore backup if found.
+
+        line: A line from the output of SteamCMD
+        """
         if not self._backup_restored and self._LOGIN_PATTERN in line:
             logging.debug("Found login pattern, restoring steamlibvdf")
             self._restore_lib_backup()
             self._backup_restored = True
 
     def _run_interactive(self, cmdline):
-        """Run SteamCMD interactively with PTY for immediate I/O."""
+        """
+        Run SteamCMD interactively with PTY for immediate I/O.
+
+        cmdline: SteamCMD arguments (list)
+        """
         self._search_buffer = ""
         max_pattern_len = len(self._LOGIN_PATTERN)
 

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -828,15 +828,17 @@ def find_most_recent_steamdir(loginvdf_paths):
     Returns Steam directory path or None if no valid paths found.
     """
     timestamps = get_mtime(loginvdf_paths)
-    
-    if not timestamps or timestamps[-1] == 0:
+    if not timestamps:
         return None
-    
+
     max_timestamp = max(timestamps)
+    if max_timestamp == 0:
+        return None
+
     for i, path in enumerate(loginvdf_paths):
         if timestamps[i] == max_timestamp:
             return os.path.dirname(os.path.dirname(path))
-    
+
     return None
 
 
@@ -907,10 +909,10 @@ def get_steamdir():
     if Args.proton:
         if Args.flatpak_steam:
             return Dir.flatpak_steamdir
-        
+
         if Args.native_steam_dir != "auto":
             return Args.native_steam_dir
-        
+
         # find directory with most recently updated "loginusers.vdf" file
         return find_most_recent_steamdir(File.loginusers_paths)
     return Args.wine_steam_dir

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -825,9 +825,9 @@ def find_most_recent_steamdir(loginvdf_paths):
     """
     Find Steam directory with most recently updated loginusers.vdf.
 
-    loginvdf_paths: loginusers.vdf paths
-
     Returns Steam directory path or None if no valid path is found.
+
+    loginvdf_paths: loginusers.vdf paths
     """
     timestamps = get_mtime(loginvdf_paths)
     if not timestamps:

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -825,7 +825,9 @@ def find_most_recent_steamdir(loginvdf_paths):
     """
     Find Steam directory with most recently updated loginusers.vdf.
 
-    Returns Steam directory path or None if no valid paths found.
+    loginvdf_paths: loginusers.vdf paths
+
+    Returns Steam directory path or None if no valid path is found.
     """
     timestamps = get_mtime(loginvdf_paths)
     if not timestamps:
@@ -877,7 +879,7 @@ def wait_for_steam(use_proton, loginvdf_paths, wine=None, env=None):
         loginvdfs_checked += loginvdf_paths
     if not check_steam_process(use_proton=use_proton, wine=wine, env=env):
         loginvdfs_timestamps = get_mtime(loginvdfs_checked)
-        logging.debug("Starting Steam...")
+        logging.info("Starting Steam...")
         if use_proton:
             subproc.Popen(
                 ("nohup", "steam"), stdout=subproc.DEVNULL, stderr=subproc.STDOUT)

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -834,7 +834,7 @@ def find_most_recent_steamdir(loginvdf_paths):
     max_timestamp = max(timestamps)
     if max_timestamp == 0:
         logging.warning(
-            "Could not find steam installation in one of these directories:\n" +
+            "Could not find steam installation in one of these directories:\n%s",
             "\n".join(loginvdf_paths)
         )
         return None

--- a/truckersmp_cli/utils.py
+++ b/truckersmp_cli/utils.py
@@ -824,7 +824,7 @@ def wait_for_loginvdf_update(
 def find_most_recent_steamdir(loginvdf_paths):
     """
     Find Steam directory with most recently updated loginusers.vdf.
-    
+
     Returns Steam directory path or None if no valid paths found.
     """
     timestamps = get_mtime(loginvdf_paths)
@@ -833,6 +833,10 @@ def find_most_recent_steamdir(loginvdf_paths):
 
     max_timestamp = max(timestamps)
     if max_timestamp == 0:
+        logging.warning(
+            "Could not find steam installation in one of these directories:\n" +
+            "\n".join(loginvdf_paths)
+        )
         return None
 
     for i, path in enumerate(loginvdf_paths):
@@ -899,7 +903,7 @@ def wait_for_steam(use_proton, loginvdf_paths, wine=None, env=None):
 def get_steamdir():
     """
     Get the Steam installation directory.
-    
+
     Returns the appropriate Steam directory based on configuration:
     - Flatpak Steam directory if using Flatpak
     - Specified directory if explicitly set


### PR DESCRIPTION
This pull request fixes the SteamCMD bug that removes steam library folders (see [#253](https://github.com/truckersmp-cli/truckersmp-cli/issues/253#issuecomment-1200485916), #367 and #368). It backs up the libraryfolders.vdf file and restores it after the login to SteamCMD.

As I do not know if this issue exists for Wine, I only implemented it for Proton for now but this can easily be changed.